### PR TITLE
Operation Analytics

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "d430a90a3641b4f444cfd3688b69e44cbd46ea927e23d93b69751e52dd3367a1",
+  "originHash" : "f66a773521439f7794ca1f0acfbaff6540a8c88ea559b6d079ea174170663d8f",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -125,6 +125,15 @@
       "state" : {
         "revision" : "f99ae8aa18f0cf0d53481901f88a0991dc3bd4a2",
         "version" : "601.0.1"
+      }
+    },
+    {
+      "identity" : "swift-uuidv7",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mhayes853/swift-uuidv7",
+      "state" : {
+        "revision" : "02c3e05095347a2649846c199adbde756f0c2e90",
+        "version" : "0.3.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -53,7 +53,8 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/swift-navigation", from: "2.3.1"),
     .package(url: "https://github.com/apple/swift-log", from: "1.6.3"),
     .package(url: "https://github.com/apple/swift-atomics", from: "1.3.0"),
-    .package(url: "https://github.com/pointfreeco/swift-perception", from: "2.0.7")
+    .package(url: "https://github.com/pointfreeco/swift-perception", from: "2.0.7"),
+    .package(url: "https://github.com/mhayes853/swift-uuidv7", from: "0.3.0")
   ],
   targets: [
     .target(
@@ -108,7 +109,12 @@ let package = Package(
     .target(
       name: "OperationTestHelpers",
       dependencies: ["Operation", .product(name: "CustomDump", package: "swift-custom-dump")]
-    )
+    ),
+    .target(
+      name: "OperationAnalytics",
+      dependencies: ["Operation", .product(name: "UUIDV7", package: "swift-uuidv7")]
+    ),
+    .testTarget(name: "OperationAnalyticsTests", dependencies: ["OperationAnalytics"])
   ],
   swiftLanguageModes: [.v6]
 )

--- a/Sources/OperationAnalytics/ApplicationLaunch.swift
+++ b/Sources/OperationAnalytics/ApplicationLaunch.swift
@@ -1,0 +1,6 @@
+import UUIDV7
+
+public struct ApplicationLaunch: Identifiable, Sendable {
+  public let id: UUIDV7
+  public let deviceName: DeviceName
+}

--- a/Sources/OperationAnalytics/DeviceName.swift
+++ b/Sources/OperationAnalytics/DeviceName.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+public struct DeviceName: Hashable, Sendable, Codable, RawRepresentable {
+  public static let current = {
+    var size: size_t = 0
+    sysctlbyname("hw.machine", nil, &size, nil, 0)
+    var machine = [CChar](repeating: 0, count: size)
+    sysctlbyname("hw.machine", &machine, &size, nil, 0)
+    let name = String(cString: &machine, encoding: String.Encoding.utf8)?
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+    return Self(rawValue: name ?? "Unknown Device")
+  }()
+
+  public let rawValue: String
+
+  public init(rawValue: String) {
+    self.rawValue = rawValue
+  }
+}


### PR DESCRIPTION
The demo app, CanIClimb, featured built-in dev tools for viewing the results of different operations across different launches. This was really helpful when debugging all sorts of various issues.

Let's make a far better and more useful version of those tools.