### PR TITLE
Stale After Duration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run tests
-        run: swift test --enable-all-traits
+        run: swift test --traits SwiftOperationLogging
 
   linux:
     name: Linux (Swift 6.2)
@@ -44,7 +44,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run tests
-        run: swift test --enable-all-traits
+        run: swift test --traits SwiftOperationLogging
 
   android:
     name: Android (Swift 6.2)
@@ -56,7 +56,7 @@ jobs:
         uses: swift-android-sdk/swift-android-action@v2
         with:
           swift-version: 6.2
-          swift-build-flags: --enable-all-traits
+          swift-build-flags: --traits SwiftOperationLogging
           run-tests: false
 
   windows:

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "d430a90a3641b4f444cfd3688b69e44cbd46ea927e23d93b69751e52dd3367a1",
+  "originHash" : "7c45073dacd4b4200a7daefb8186bcf0057090492f73aba2da4e6a60f18817d1",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftwasm/JavaScriptKit",
       "state" : {
-        "revision" : "1603fce33630df9e6064ad321d6ca0a8dde8c785",
-        "version" : "0.35.0"
+        "revision" : "a069e3af73ab950220d054d2488120b8f54585cf",
+        "version" : "0.36.0"
       }
     },
     {
@@ -26,6 +26,15 @@
       "state" : {
         "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
         "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-case-paths",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-case-paths",
+      "state" : {
+        "revision" : "6989976265be3f8d2b5802c722f9ba168e227c71",
+        "version" : "1.7.2"
       }
     },
     {
@@ -42,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections",
       "state" : {
-        "revision" : "8c0c0a8b49e080e54e5e328cc552821ff07cd341",
-        "version" : "1.2.1"
+        "revision" : "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
+        "version" : "1.3.0"
       }
     },
     {
@@ -51,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
       "state" : {
-        "revision" : "82a4ae7170d98d8538ec77238b7eb8e7199ef2e8",
-        "version" : "1.3.1"
+        "revision" : "5a3825302b1a0d744183200915a47b508c828e6f",
+        "version" : "1.3.2"
       }
     },
     {
@@ -69,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies",
       "state" : {
-        "revision" : "a501eebe552fd23691c560adf474fca2169ad8aa",
-        "version" : "1.9.4"
+        "revision" : "a10f9feeb214bc72b5337b6ef6d5a029360db4cc",
+        "version" : "1.10.0"
       }
     },
     {
@@ -101,12 +110,30 @@
       }
     },
     {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log",
+      "state" : {
+        "revision" : "ce592ae52f982c847a4efc0dd881cc9eb32d29f2",
+        "version" : "1.6.4"
+      }
+    },
+    {
+      "identity" : "swift-navigation",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-navigation",
+      "state" : {
+        "revision" : "bf498690e1f6b4af790260f542e8428a4ba10d78",
+        "version" : "2.6.0"
+      }
+    },
+    {
       "identity" : "swift-perception",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-perception",
       "state" : {
-        "revision" : "52bc59a5c7c3f0420c6c31d643d55d64b3f8c013",
-        "version" : "2.0.7"
+        "revision" : "4f47ebafed5f0b0172cf5c661454fa8e28fb2ac4",
+        "version" : "2.0.9"
       }
     },
     {
@@ -114,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-sharing",
       "state" : {
-        "revision" : "530c98ac2c3e393615616bd6d8fc604600c99f6f",
-        "version" : "2.7.2"
+        "revision" : "3bfc408cc2d0bee2287c174da6b1c76768377818",
+        "version" : "2.7.4"
       }
     },
     {
@@ -132,8 +159,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "b2ed9eabefe56202ee4939dd9fc46b6241c88317",
-        "version" : "1.6.1"
+        "revision" : "4c27acf5394b645b70d8ba19dc249c0472d5f618",
+        "version" : "1.7.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -50,7 +50,7 @@ let package = Package(
     ),
     .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.4.3"),
     .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.4.3"),
-    .package(url: "https://github.com/pointfreeco/swift-navigation", from: "2.3.1"),
+    .package(url: "https://github.com/pointfreeco/swift-navigation", from: "2.6.0"),
     .package(url: "https://github.com/apple/swift-log", from: "1.6.3"),
     .package(url: "https://github.com/apple/swift-atomics", from: "1.3.0"),
     .package(url: "https://github.com/pointfreeco/swift-perception", from: "2.0.7")

--- a/Tests/OperationTests/ModifiersTests/StaleWhenRevalidateOperationTests.swift
+++ b/Tests/OperationTests/ModifiersTests/StaleWhenRevalidateOperationTests.swift
@@ -94,6 +94,22 @@ struct StaleWhenRevalidateOperationTests {
     expectNoDifference(store.isStale, true)
   }
 
+  @Test("Stale After Duration")
+  func staleAfterDuration() async throws {
+    let clock = TestOperationClock(date: Date())
+    let query = TestQuery().stale(after: .seconds(1))
+    let store = OperationStore.detached(query: query, initialValue: nil)
+    store.context.operationClock = clock
+
+    expectNoDifference(store.isStale, true)
+
+    try await store.fetch()
+    expectNoDifference(store.isStale, false)
+
+    clock.date += 2
+    expectNoDifference(store.isStale, true)
+  }
+
   @Test("Stale When No Value")
   func staleWhenHasValue() async throws {
     let query = TestQuery().staleWhenNoValue()


### PR DESCRIPTION
The existing `stale(after:)` modifier only utilized a `TimeInterval`, but we can get more precision by making it based on `OperationDuration` or `Duration` instead. As a result, I've deprecated the `TimeInterval` API in exchange for an equivalent set of APIs that use both duration types.

Additionally, if no value was present, then the operation was considered stale by default. This behavior is now customizable with the `whenNoValue` parameter, which is true by default.