### PR TITLE
`OperationRunner` + `AnyOperation`

### DIFF
--- a/Sources/OperationCore/AnyOperation.swift
+++ b/Sources/OperationCore/AnyOperation.swift
@@ -1,6 +1,11 @@
+/// A type-erased ``OperationRequest``.
 public struct AnyOperation<Value, Failure: Error>: OperationRequest {
+  /// An existential to the erased operation.
   public let base: any OperationRequest<Value, Failure>
-
+  
+  /// Type erases an ``OperationRequest``.
+  ///
+  /// - Parameter operation: The operation to erase.
   public init(_ operation: some OperationRequest<Value, Failure>) {
     self.base = operation
   }

--- a/Sources/OperationCore/AnyOperation.swift
+++ b/Sources/OperationCore/AnyOperation.swift
@@ -1,0 +1,19 @@
+public struct AnyOperation<Value, Failure: Error>: OperationRequest {
+  public let base: any OperationRequest<Value, Failure>
+
+  public init(_ operation: some OperationRequest<Value, Failure>) {
+    self.base = operation
+  }
+
+  public func setup(context: inout OperationContext) {
+    self.base.setup(context: &context)
+  }
+
+  public func run(
+    isolation: isolated (any Actor)?,
+    in context: OperationContext,
+    with continuation: OperationContinuation<Value, Failure>
+  ) async throws(Failure) -> Value {
+    try await self.base.run(isolation: isolation, in: context, with: continuation)
+  }
+}

--- a/Sources/OperationCore/DefaultOperation.swift
+++ b/Sources/OperationCore/DefaultOperation.swift
@@ -109,19 +109,19 @@ public protocol DefaultableOperationState: OperationState {
   /// If ``OperationState/StateValue`` is an optional, this is typically a non-optional version of
   /// that type.
   associatedtype DefaultStateValue: Sendable
-  
+
   /// Returns the current value of this state based on the default value.
   ///
   /// - Parameter defaultValue: The default value of the operation state.
   /// - Returns: The current state's value based on the default value.
   func currentValue(using defaultValue: DefaultStateValue) -> DefaultStateValue
-  
+
   /// Returns the initial value of this state based on the default value.
   ///
   /// - Parameter defaultValue: The default value of the operation state.
   /// - Returns: The initial state's value based on the default value.
   func initialValue(using defaultValue: DefaultStateValue) -> DefaultStateValue
-  
+
   /// Converts a value of type ``DefaultStateValue`` to a value of the base
   /// ``OperationState/StateValue`` type on this state.
   ///
@@ -165,10 +165,10 @@ public struct DefaultOperationState<Base: DefaultableOperationState>: OperationS
 
   /// The base state.
   public private(set) var base: Base
-  
+
   /// The default value applied to the base state.
   public let defaultValue: Base.DefaultStateValue
-  
+
   /// Creates a default operation state.
   ///
   /// - Parameters:

--- a/Sources/OperationCore/Documentation.docc/OperationCore.md
+++ b/Sources/OperationCore/Documentation.docc/OperationCore.md
@@ -393,6 +393,8 @@ The library ships with a handful of package traits, which allow you to condition
 - ``OperationRequest``
 - ``OperationContext``
 - ``OperationContinuation``
+- ``OperationRunner``
+- ``AnyOperation``
 - ``QueryRequest``
 - ``MutationRequest``
 - ``PaginatedRequest``

--- a/Sources/OperationCore/OperationRequest.swift
+++ b/Sources/OperationCore/OperationRequest.swift
@@ -64,7 +64,8 @@ public protocol OperationRequest<Value, Failure> {
   /// Sets up an ``OperationContext`` in preparation for it being passed to
   /// ``run(isolation:in:with:)``.
   ///
-  /// This method is called a single time when an ``OperationStore`` is initialized with this operation.
+  /// This method is called a single time when an ``OperationStore`` or ``OperationRunner`` is
+  /// initialized with this operation.
   ///
   /// - Parameter context: The context to setup.
   func setup(context: inout OperationContext)
@@ -76,7 +77,7 @@ public protocol OperationRequest<Value, Failure> {
   ///   - context: An ``OperationContext`` that is passed to this operation.
   ///   - continuation: An ``OperationContinuation`` that allows you to yield data while this
   ///   operation is still running. See <doc:MultistageOperations> for more.
-  /// - Returns: The value return from this operation.
+  /// - Returns: The value returned from this operation.
   func run(
     isolation: isolated (any Actor)?,
     in context: OperationContext,

--- a/Sources/OperationCore/OperationRunner.swift
+++ b/Sources/OperationCore/OperationRunner.swift
@@ -1,14 +1,50 @@
+/// A simple runtime for an ``OperationRequest``.
+///
+/// ```swift
+/// struct MyOperation: OperationRequest {
+///   // ...
+/// }
+///
+/// let runner = OperationRunner(operation: MyOperation())
+/// let value = try await runner.run()
+///
+/// // ...
+/// ```
+///
+/// The runner makes sure to invoke ``OperationRequest/setup(context:)-8y79v`` once during
+/// ``init(operation:initialContext:)``. You can also modify the ``OperationContext`` that gets
+/// handed to each operation run by modifying the ``context`` property, or by passing a dedicated
+/// context to ``run(isolation:in:with:)``.
 public struct OperationRunner<Operation: OperationRequest> {
+  /// The current ``OperationContext`` associated with the underlying operation.
   public var context: OperationContext
+  
   private let operation: Operation
-
+  
+  /// Creates a runner.
+  ///
+  /// This initializer invokes ``OperationRequest/setup(context:)-8y79v`` on the specified
+  /// `operation` with an an inout ``OperationContext`` reference based on `initialContext`.
+  ///
+  /// - Parameters:
+  ///   - operation: The ``OperationRequest`` to run.
+  ///   - initialContext: The initial ``OperationContext`` for the operation.
   public init(operation: Operation, initialContext: OperationContext = OperationContext()) {
     var context = initialContext
     operation.setup(context: &context)
     self.context = context
     self.operation = operation
   }
-
+  
+  /// Runs the underlying operation of this runner.
+  ///
+  /// - Parameters:
+  ///   - isolation: The current actor-isolation of this operation run.
+  ///   - context: The ``OperationContext`` to pass to the operation run. (Defaults to the
+  ///   ``context`` instance property if nil).
+  ///   - continuation: An ``OperationContinuation`` that allows you to yield data while the
+  ///   underlying operation is still running. See <doc:MultistageOperations> for more.
+  /// - Returns: The value returned from the underlying operation.
   public func run(
     isolation: isolated (any Actor)? = #isolation,
     in context: OperationContext? = nil,

--- a/Sources/OperationCore/OperationRunner.swift
+++ b/Sources/OperationCore/OperationRunner.swift
@@ -1,0 +1,26 @@
+public struct OperationRunner<Operation: OperationRequest> {
+  public var context: OperationContext
+  private let operation: Operation
+
+  public init(operation: Operation, initialContext: OperationContext = OperationContext()) {
+    var context = initialContext
+    operation.setup(context: &context)
+    self.context = context
+    self.operation = operation
+  }
+
+  public func run(
+    isolation: isolated (any Actor)? = #isolation,
+    in context: OperationContext? = nil,
+    with continuation: OperationContinuation<Operation.Value, Operation.Failure> =
+      OperationContinuation { _, _ in }
+  ) async throws(Operation.Failure) -> Operation.Value {
+    try await self.operation.run(
+      isolation: isolation,
+      in: context ?? self.context,
+      with: continuation
+    )
+  }
+}
+
+extension OperationRunner: Sendable where Operation: Sendable {}


### PR DESCRIPTION
There wasn't a good runtime for stateless operations (stateful operations have `OperationStore`), so let's make one. `OperationRunner` has a concrete generic on an `OperationRequest` unlike `OperationStore`, so let's also introduce `AnyOperation` to enable type-erasure for stateless operations. 

I'm against adding a type-eraser for stateful operations due to the warning checks inside `OperationClient`. If 2 stateful operations with the same `path` have different sets of modifiers applied to them, `OperationClient` won't be able to distinguish between the 2 instances which is undefined behavior atm.

Also, `OperationStore` can use `OperationRunner` and `AnyOperation` under the hood.