### PR TITLE
Better QueryRequest and MutationRequest Macro Error Messages

### DIFF
--- a/Examples/CanIClimb/CanIClimbKit/Tests/CanIClimbKitTests/MountainsCoreTests/ClimbReadinessTests/__Snapshots__/Mountain+ClimbReadinessFoundationModelsTests/generationActivePerson-json.1.json
+++ b/Examples/CanIClimb/CanIClimbKit/Tests/CanIClimbKitTests/MountainsCoreTests/ClimbReadinessTests/__Snapshots__/Mountain+ClimbReadinessFoundationModelsTests/generationActivePerson-json.1.json
@@ -3,7 +3,7 @@
 
   ],
   "readiness" : {
-    "insight" : "Based on your active activity level and daily workout routine, you have a good foundation for climbing, but your VO2 max, step count, daily distance traveled, and current weather conditions need improvement. Consider doing a few preparation climbs to build endurance, focus on a specific training regiment to enhance cardiovascular fitness, and ensure you are well-hydrated and nourished. Consult with a fitness professional to create a personalized training plan.",
+    "insight" : "Based on your active activity level and daily workouts, you have a good foundation for climbing, but you may need to increase your stamina and strength to tackle the challenging terrain of Freel Peak. To prepare, consider incorporating more endurance training, strength exercises, and possibly some altitude training to better simulate mountain conditions.",
     "rating" : {
       "partiallyReady" : {
 

--- a/Examples/CanIClimb/CanIClimbKit/Tests/CanIClimbKitTests/MountainsCoreTests/ClimbReadinessTests/__Snapshots__/Mountain+ClimbReadinessFoundationModelsTests/generationInactivePerson-json.1.json
+++ b/Examples/CanIClimb/CanIClimbKit/Tests/CanIClimbKitTests/MountainsCoreTests/ClimbReadinessTests/__Snapshots__/Mountain+ClimbReadinessFoundationModelsTests/generationInactivePerson-json.1.json
@@ -1,26 +1,6 @@
 {
   "messages" : [
     {
-      "content" : "'userVO2Max' tool called.",
-      "metadata" : {
-        "call.arguments" : {
-          "string" : {
-            "_0" : "Arguments(query: \"last 6 weeks\")"
-          }
-        },
-        "call.duration" : {
-          "string" : {
-            "_0" : "0.001209042 seconds"
-          }
-        },
-        "call.result" : {
-          "string" : {
-            "_0" : "success(CanIClimbKit.NumericHealthSamples(kind: CanIClimbKit.NumericHealthSamples.Kind.vo2Max, elements: [CanIClimbKit.NumericHealthSamples.Element(timestamp: 2025-11-10 09:17:34 +0000, value: 33.4)]))"
-          }
-        }
-      }
-    },
-    {
       "content" : "'userLocation' tool called.",
       "metadata" : {
         "call.arguments" : {
@@ -30,7 +10,7 @@
         },
         "call.duration" : {
           "string" : {
-            "_0" : "0.001070375 seconds"
+            "_0" : "0.001222125 seconds"
           }
         },
         "call.result" : {
@@ -39,12 +19,32 @@
           }
         }
       }
+    },
+    {
+      "content" : "'userVO2Max' tool called.",
+      "metadata" : {
+        "call.arguments" : {
+          "string" : {
+            "_0" : "Arguments(query: \"last 6 weeks\")"
+          }
+        },
+        "call.duration" : {
+          "string" : {
+            "_0" : "0.001302916 seconds"
+          }
+        },
+        "call.result" : {
+          "string" : {
+            "_0" : "success(CanIClimbKit.NumericHealthSamples(kind: CanIClimbKit.NumericHealthSamples.Kind.vo2Max, elements: [CanIClimbKit.NumericHealthSamples.Element(timestamp: 2025-11-11 19:40:35 +0000, value: 33.4)]))"
+          }
+        }
+      }
     }
   ],
   "readiness" : {
-    "insight" : "Based on the VO2 Max reading of 33.4 ml\/kg\/min and your sedentary activity level, you are not currently ready to climb Freel Peak. Freel Peak is rated as a difficult climb with an elevation of 3,318.0528 meters. To prepare, you should gradually increase your cardiovascular fitness through regular aerobic exercise, such as hiking or running, and incorporate strength training to build muscle endurance. Aim for at least 3-4 days of exercise per week, and progressively increase the intensity and duration of your workouts as your fitness improves. Additionally, ensure proper nutrition to support your training and consider acclimatizing to high altitudes if possible before attempting the climb.",
+    "insight" : "Based on your current VO2 Max of 33.4 ml\/kg\/min, which indicates a sedentary fitness level, coupled with your sedentary activity level and no workout frequency, you are not yet fully prepared for climbing Freel Peak. This mountain is rated as difficult with an elevation of 3,318 meters. To improve your readiness, consider incorporating regular cardiovascular exercise, strength training, and gradually increasing your stamina through long-distance walking or running. Aim for at least 3-4 days of moderate exercise per week and gradually work up to more intense climbs. Additionally, ensure proper nutrition and stay hydrated, especially given the mountain's snowy conditions that may affect weather patterns.",
     "rating" : {
-      "notReady" : {
+      "partiallyReady" : {
 
       }
     }

--- a/Sources/Operation/Macros.swift
+++ b/Sources/Operation/Macros.swift
@@ -58,14 +58,14 @@ public struct _OperationPathMacroSynthesizer: Sendable {
   ///
   /// Only use this if the arguments to your operation would syntesize a Hashable conformance.
   public static let inferredFromHashable = Self()
-  
+
   /// Synthesizes the `OperationPath` requirement of an operation to be the identity of the
   /// operation type.
   ///
   /// Only use this if one of the arguments to your operation is named `id` with a type that
   /// conforms to Hashable.
   public static let inferredFromIdentifiable = Self()
-  
+
   /// Synthesizes the `OperationPath` requirement of an operation to the result of a custom
   /// closure that you specify.
   ///
@@ -97,4 +97,16 @@ public struct _OperationHashableMetatype<T>: Hashable, Sendable {
   public func hash(into hasher: inout Hasher) {
     hasher.combine(ObjectIdentifier(self.type))
   }
+}
+
+// MARK: - Type Requirements
+
+@_transparent
+public func _operationRequireHashable<T: Hashable>(_ value: T) -> T {
+  value
+}
+
+@_transparent
+public func _operationRequireSendable<T: Sendable>(_ value: T) -> T {
+  value
 }

--- a/Sources/OperationMacros/Internal/OperationFunctionSyntax.swift
+++ b/Sources/OperationMacros/Internal/OperationFunctionSyntax.swift
@@ -89,7 +89,7 @@ struct OperationFunctionSyntax {
     case sendable
   }
 
-  func createOperationTypeInvoke(typeChecks: Set<CreateOperationInvokeTypeCheck> = []) -> String {
+  func createOperationTypeInvoke(typeChecks: [CreateOperationInvokeTypeCheck] = []) -> String {
     var invoke = self.functionArgs
       .compactMap { functionArg -> String? in
         let name = functionArg.operationalName
@@ -142,7 +142,7 @@ struct OperationFunctionSyntax {
       """
   }
 
-  func accessorProperty(typeChecks: Set<CreateOperationInvokeTypeCheck> = []) -> String {
+  func accessorProperty(typeChecks: [CreateOperationInvokeTypeCheck] = []) -> String {
     let isFunction = self.hasNonReservedArgs || self.hasGenericArgs
     return """
       \(self.declaration.availability ?? "")

--- a/Sources/OperationMacros/Internal/PathSyntesizerSyntax.swift
+++ b/Sources/OperationMacros/Internal/PathSyntesizerSyntax.swift
@@ -17,14 +17,14 @@ enum PathSyntesizerSyntax {
     }
   }
 
-  var requiredTypeChecks: Set<OperationFunctionSyntax.CreateOperationInvokeTypeCheck> {
-    var checks = Set<OperationFunctionSyntax.CreateOperationInvokeTypeCheck>()
+  var requiredTypeChecks: [OperationFunctionSyntax.CreateOperationInvokeTypeCheck] {
+    var checks = [OperationFunctionSyntax.CreateOperationInvokeTypeCheck]()
     switch self {
     case .inferredFromHashable:
-      checks.insert(.hashable)
-      checks.insert(.sendable)
+      checks.append(.hashable)
+      checks.append(.sendable)
     case .inferredFromIdentifiable:
-      checks.insert(.idHashableSendable)
+      checks.append(.idHashableSendable)
     case .custom:
       break
     }

--- a/Sources/OperationMacros/Internal/String+FirstCharacterCapitalized.swift
+++ b/Sources/OperationMacros/Internal/String+FirstCharacterCapitalized.swift
@@ -1,6 +1,0 @@
-extension StringProtocol {
-  var firstCharacterCapitalized: String {
-    guard let first else { return "" }
-    return first.uppercased() + self.dropFirst()
-  }
-}

--- a/Sources/OperationMacros/MutationRequestMacro.swift
+++ b/Sources/OperationMacros/MutationRequestMacro.swift
@@ -30,7 +30,7 @@ public enum MutationRequestMacro: PeerMacro {
 
     return [
       """
-      \(raw: syntax.accessorProperty)
+      \(raw: syntax.accessorProperty(typeChecks: pathSynthesizer.requiredTypeChecks))
       """,
       """
       \(raw: syntax.declaration.availability ?? "")

--- a/Sources/OperationMacros/OperationRequestMacro.swift
+++ b/Sources/OperationMacros/OperationRequestMacro.swift
@@ -21,7 +21,7 @@ public enum OperationRequestMacro: PeerMacro {
 
     return [
       """
-      \(raw: syntax.accessorProperty)
+      \(raw: syntax.accessorProperty())
       """,
       """
       \(raw: syntax.declaration.availability ?? "")

--- a/Sources/OperationMacros/QueryRequestMacro.swift
+++ b/Sources/OperationMacros/QueryRequestMacro.swift
@@ -20,7 +20,7 @@ public enum QueryRequestMacro: PeerMacro {
     let typeConformance = pathSynthesizer.operationTypeConformance.map { ", \($0)" } ?? ""
     return [
       """
-      \(raw: syntax.accessorProperty)
+      \(raw: syntax.accessorProperty(typeChecks: pathSynthesizer.requiredTypeChecks))
       """,
       """
       \(raw: syntax.declaration.availability ?? "")

--- a/Tests/OperationMacrosTests/MutationRequestMacroTests.swift
+++ b/Tests/OperationMacrosTests/MutationRequestMacroTests.swift
@@ -209,7 +209,7 @@ extension BaseTestSuite {
         }
 
         nonisolated func $something(with arg: Int, with arg2: String) -> __macro_local_9somethingfMu_ {
-          __macro_local_9somethingfMu_(arg: _operationRequireHashable(_operationRequireSendable(arg)), arg2: _operationRequireHashable(_operationRequireSendable(arg2)))
+          __macro_local_9somethingfMu_(arg: _operationRequireSendable(_operationRequireHashable(arg)), arg2: _operationRequireSendable(_operationRequireHashable(arg2)))
         }
 
         nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable, Sendable {
@@ -245,7 +245,7 @@ extension BaseTestSuite {
         }
 
         nonisolated func $something(arg: Int = 0) -> __macro_local_9somethingfMu_ {
-          __macro_local_9somethingfMu_(arg: _operationRequireHashable(_operationRequireSendable(arg)))
+          __macro_local_9somethingfMu_(arg: _operationRequireSendable(_operationRequireHashable(arg)))
         }
 
         nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable, Sendable {
@@ -328,7 +328,7 @@ extension BaseTestSuite {
         }
 
         nonisolated func $something(arg: Int,) -> __macro_local_9somethingfMu_ {
-          __macro_local_9somethingfMu_(arg: _operationRequireHashable(_operationRequireSendable(arg)))
+          __macro_local_9somethingfMu_(arg: _operationRequireSendable(_operationRequireHashable(arg)))
         }
 
         nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable, Sendable {
@@ -371,7 +371,7 @@ extension BaseTestSuite {
         }
 
         nonisolated func $something(arg: Int,) -> __macro_local_9somethingfMu_ {
-          __macro_local_9somethingfMu_(arg: _operationRequireHashable(_operationRequireSendable(arg)))
+          __macro_local_9somethingfMu_(arg: _operationRequireSendable(_operationRequireHashable(arg)))
         }
 
         nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable, Sendable {
@@ -416,7 +416,7 @@ extension BaseTestSuite {
         }
 
         nonisolated func $something(arg: Int,) -> __macro_local_9somethingfMu_ {
-          __macro_local_9somethingfMu_(arg: _operationRequireHashable(_operationRequireSendable(arg)))
+          __macro_local_9somethingfMu_(arg: _operationRequireSendable(_operationRequireHashable(arg)))
         }
 
         nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable, Sendable {
@@ -716,7 +716,7 @@ extension BaseTestSuite {
           }
 
           nonisolated func $something(arg: Int) -> __macro_local_9somethingfMu_ {
-            __macro_local_9somethingfMu_(arg: _operationRequireHashable(_operationRequireSendable(arg)))
+            __macro_local_9somethingfMu_(arg: _operationRequireSendable(_operationRequireHashable(arg)))
           }
 
           nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable, Sendable {
@@ -758,7 +758,7 @@ extension BaseTestSuite {
             }
 
             nonisolated func $something(arg: Int) -> __macro_local_9somethingfMu_ {
-              __macro_local_9somethingfMu_(arg: _operationRequireHashable(_operationRequireSendable(arg)), __macro_local_4typefMu_: self)
+              __macro_local_9somethingfMu_(arg: _operationRequireSendable(_operationRequireHashable(arg)), __macro_local_4typefMu_: self)
             }
 
             nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable, Sendable {
@@ -827,7 +827,7 @@ extension BaseTestSuite {
         }
 
         private nonisolated func $something(arg: Int) -> __macro_local_9somethingfMu_ {
-          __macro_local_9somethingfMu_(arg: _operationRequireHashable(_operationRequireSendable(arg)))
+          __macro_local_9somethingfMu_(arg: _operationRequireSendable(_operationRequireHashable(arg)))
         }
 
         private nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable, Sendable {
@@ -858,7 +858,7 @@ extension BaseTestSuite {
         }
 
         fileprivate nonisolated func $something(arg: Int) -> __macro_local_9somethingfMu_ {
-          __macro_local_9somethingfMu_(arg: _operationRequireHashable(_operationRequireSendable(arg)))
+          __macro_local_9somethingfMu_(arg: _operationRequireSendable(_operationRequireHashable(arg)))
         }
 
         fileprivate nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable, Sendable {
@@ -896,7 +896,7 @@ extension BaseTestSuite {
 
         @available(iOS 13.0, *)
         nonisolated func $something(arg: Int) -> __macro_local_9somethingfMu_ {
-          __macro_local_9somethingfMu_(arg: _operationRequireHashable(_operationRequireSendable(arg)))
+          __macro_local_9somethingfMu_(arg: _operationRequireSendable(_operationRequireHashable(arg)))
         }
 
         @available(iOS 13.0, *)

--- a/Tests/OperationMacrosTests/MutationRequestMacroTests.swift
+++ b/Tests/OperationMacrosTests/MutationRequestMacroTests.swift
@@ -24,11 +24,9 @@ extension BaseTestSuite {
           __macro_local_9somethingfMu_()
         }
 
-        nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable {
+        nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable, Sendable {
 
-          var path: OperationCore.OperationPath {
-          OperationCore.OperationPath(self)
-          }
+
           func mutate(
             isolation: isolated (any Actor)?,
             with arguments: Void,
@@ -61,11 +59,9 @@ extension BaseTestSuite {
           __macro_local_9somethingfMu_()
         }
 
-        nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable {
+        nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable, Sendable {
 
-          var path: OperationCore.OperationPath {
-          OperationCore.OperationPath(self)
-          }
+
           func mutate(
             isolation: isolated (any Actor)?,
             with arguments: Void,
@@ -107,11 +103,9 @@ extension BaseTestSuite {
           __macro_local_9somethingfMu_()
         }
 
-        nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable {
+        nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable, Sendable {
 
-          var path: OperationCore.OperationPath {
-          OperationCore.OperationPath(self)
-          }
+
           func mutate(
             isolation: isolated (any Actor)?,
             with arguments: Args,
@@ -141,15 +135,13 @@ extension BaseTestSuite {
         }
 
         nonisolated func $something(arg: Int, with arg2: String) -> __macro_local_9somethingfMu_ {
-          __macro_local_9somethingfMu_(arg: arg, arg2: arg2)
+          __macro_local_9somethingfMu_(arg: _operationRequireSendable(_operationRequireHashable(arg)), arg2: _operationRequireSendable(_operationRequireHashable(arg2)))
         }
 
-        nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable {
+        nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable, Sendable {
           let arg: Int
           let arg2: String
-          var path: OperationCore.OperationPath {
-          OperationCore.OperationPath(self)
-          }
+
           func mutate(
             isolation: isolated (any Actor)?,
             with arguments: Void,
@@ -185,11 +177,9 @@ extension BaseTestSuite {
           __macro_local_9somethingfMu_()
         }
 
-        nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable {
+        nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable, Sendable {
 
-          var path: OperationCore.OperationPath {
-          OperationCore.OperationPath(self)
-          }
+
           func mutate(
             isolation: isolated (any Actor)?,
             with arguments: Arguments,
@@ -219,15 +209,13 @@ extension BaseTestSuite {
         }
 
         nonisolated func $something(with arg: Int, with arg2: String) -> __macro_local_9somethingfMu_ {
-          __macro_local_9somethingfMu_(arg: arg, arg2: arg2)
+          __macro_local_9somethingfMu_(arg: _operationRequireHashable(_operationRequireSendable(arg)), arg2: _operationRequireHashable(_operationRequireSendable(arg2)))
         }
 
-        nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable {
+        nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable, Sendable {
           let arg: Int
           let arg2: String
-          var path: OperationCore.OperationPath {
-          OperationCore.OperationPath(self)
-          }
+
           func mutate(
             isolation: isolated (any Actor)?,
             with arguments: Void,
@@ -257,14 +245,12 @@ extension BaseTestSuite {
         }
 
         nonisolated func $something(arg: Int = 0) -> __macro_local_9somethingfMu_ {
-          __macro_local_9somethingfMu_(arg: arg)
+          __macro_local_9somethingfMu_(arg: _operationRequireHashable(_operationRequireSendable(arg)))
         }
 
-        nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable {
+        nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable, Sendable {
           let arg: Int
-          var path: OperationCore.OperationPath {
-          OperationCore.OperationPath(self)
-          }
+
           func mutate(
             isolation: isolated (any Actor)?,
             with arguments: Void,
@@ -342,14 +328,12 @@ extension BaseTestSuite {
         }
 
         nonisolated func $something(arg: Int,) -> __macro_local_9somethingfMu_ {
-          __macro_local_9somethingfMu_(arg: arg)
+          __macro_local_9somethingfMu_(arg: _operationRequireHashable(_operationRequireSendable(arg)))
         }
 
-        nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable {
+        nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable, Sendable {
           let arg: Int
-          var path: OperationCore.OperationPath {
-          OperationCore.OperationPath(self)
-          }
+
           func mutate(
             isolation: isolated (any Actor)?,
             with arguments: Void,
@@ -387,14 +371,12 @@ extension BaseTestSuite {
         }
 
         nonisolated func $something(arg: Int,) -> __macro_local_9somethingfMu_ {
-          __macro_local_9somethingfMu_(arg: arg)
+          __macro_local_9somethingfMu_(arg: _operationRequireHashable(_operationRequireSendable(arg)))
         }
 
-        nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable {
+        nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable, Sendable {
           let arg: Int
-          var path: OperationCore.OperationPath {
-          OperationCore.OperationPath(self)
-          }
+
           func mutate(
             isolation: isolated (any Actor)?,
             with arguments: Void,
@@ -434,14 +416,12 @@ extension BaseTestSuite {
         }
 
         nonisolated func $something(arg: Int,) -> __macro_local_9somethingfMu_ {
-          __macro_local_9somethingfMu_(arg: arg)
+          __macro_local_9somethingfMu_(arg: _operationRequireHashable(_operationRequireSendable(arg)))
         }
 
-        nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable {
+        nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable, Sendable {
           let arg: Int
-          var path: OperationCore.OperationPath {
-          OperationCore.OperationPath(self)
-          }
+
           func mutate(
             isolation: isolated (any Actor)?,
             with arguments: Void,
@@ -482,11 +462,9 @@ extension BaseTestSuite {
           __macro_local_9somethingfMu_()
         }
 
-        nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable {
+        nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable, Sendable {
 
-          var path: OperationCore.OperationPath {
-          OperationCore.OperationPath(self)
-          }
+
           func mutate(
             isolation: isolated (any Actor)?,
             with arguments: Void,
@@ -519,15 +497,13 @@ extension BaseTestSuite {
           }
 
           static nonisolated func $something(arg: Int) -> __macro_local_9somethingfMu_ {
-            __macro_local_9somethingfMu_(arg: arg, __macro_local_4typefMu_: _OperationHashableMetatype(type: Foo.self))
+            __macro_local_9somethingfMu_(arg: _operationRequireSendable(_operationRequireHashable(arg)), __macro_local_4typefMu_: _OperationHashableMetatype(type: Foo.self))
           }
 
-          nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable {
+          nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable, Sendable {
             let arg: Int
             let __macro_local_4typefMu_: _OperationHashableMetatype<Foo>
-            var path: OperationCore.OperationPath {
-            OperationCore.OperationPath(self)
-            }
+
             func mutate(
               isolation: isolated (any Actor)?,
               with arguments: Void,
@@ -567,11 +543,9 @@ extension BaseTestSuite {
             __macro_local_9somethingfMu_(__macro_local_4typefMu_: _OperationHashableMetatype(type: Foo.self))
           }
 
-          nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable {
+          nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable, Sendable {
             let __macro_local_4typefMu_: _OperationHashableMetatype<Foo>
-            var path: OperationCore.OperationPath {
-            OperationCore.OperationPath(self)
-            }
+
             func mutate(
               isolation: isolated (any Actor)?,
               with arguments: Void,
@@ -611,15 +585,13 @@ extension BaseTestSuite {
           }
 
           static nonisolated func $something(arg: Int) -> __macro_local_9somethingfMu_ {
-            __macro_local_9somethingfMu_(arg: arg, __macro_local_4typefMu_: _OperationHashableMetatype(type: Foo.self))
+            __macro_local_9somethingfMu_(arg: _operationRequireSendable(_operationRequireHashable(arg)), __macro_local_4typefMu_: _OperationHashableMetatype(type: Foo.self))
           }
 
-          nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable {
+          nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable, Sendable {
             let arg: Int
             let __macro_local_4typefMu_: _OperationHashableMetatype<Foo>
-            var path: OperationCore.OperationPath {
-            OperationCore.OperationPath(self)
-            }
+
             func mutate(
               isolation: isolated (any Actor)?,
               with arguments: Void,
@@ -656,15 +628,13 @@ extension BaseTestSuite {
           }
 
           nonisolated func $something(arg: Int) -> __macro_local_9somethingfMu_ {
-            __macro_local_9somethingfMu_(arg: arg, __macro_local_4typefMu_: self)
+            __macro_local_9somethingfMu_(arg: _operationRequireSendable(_operationRequireHashable(arg)), __macro_local_4typefMu_: self)
           }
 
-          nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable {
+          nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable, Sendable {
             let arg: Int
             let __macro_local_4typefMu_: Foo
-            var path: OperationCore.OperationPath {
-            OperationCore.OperationPath(self)
-            }
+
             func mutate(
               isolation: isolated (any Actor)?,
               with arguments: Void,
@@ -706,15 +676,13 @@ extension BaseTestSuite {
           }
 
           nonisolated func $something(arg: Int) -> __macro_local_9somethingfMu_ {
-            __macro_local_9somethingfMu_(arg: arg, __macro_local_4typefMu_: self)
+            __macro_local_9somethingfMu_(arg: _operationRequireSendable(_operationRequireHashable(arg)), __macro_local_4typefMu_: self)
           }
 
-          nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable {
+          nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable, Sendable {
             let arg: Int
             let __macro_local_4typefMu_: Foo
-            var path: OperationCore.OperationPath {
-            OperationCore.OperationPath(self)
-            }
+
             func mutate(
               isolation: isolated (any Actor)?,
               with arguments: Void,
@@ -748,14 +716,12 @@ extension BaseTestSuite {
           }
 
           nonisolated func $something(arg: Int) -> __macro_local_9somethingfMu_ {
-            __macro_local_9somethingfMu_(arg: arg)
+            __macro_local_9somethingfMu_(arg: _operationRequireHashable(_operationRequireSendable(arg)))
           }
 
-          nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable {
+          nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable, Sendable {
             let arg: Int
-            var path: OperationCore.OperationPath {
-            OperationCore.OperationPath(self)
-            }
+
             func mutate(
               isolation: isolated (any Actor)?,
               with arguments: Void,
@@ -792,15 +758,13 @@ extension BaseTestSuite {
             }
 
             nonisolated func $something(arg: Int) -> __macro_local_9somethingfMu_ {
-              __macro_local_9somethingfMu_(arg: arg, __macro_local_4typefMu_: self)
+              __macro_local_9somethingfMu_(arg: _operationRequireHashable(_operationRequireSendable(arg)), __macro_local_4typefMu_: self)
             }
 
-            nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable {
+            nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable, Sendable {
               let arg: Int
               let __macro_local_4typefMu_: Foo
-              var path: OperationCore.OperationPath {
-              OperationCore.OperationPath(self)
-              }
+
               func mutate(
                 isolation: isolated (any Actor)?,
                 with arguments: Void,
@@ -832,14 +796,12 @@ extension BaseTestSuite {
         }
 
         public nonisolated func $something(arg: Int) -> __macro_local_9somethingfMu_ {
-          __macro_local_9somethingfMu_(arg: arg)
+          __macro_local_9somethingfMu_(arg: _operationRequireSendable(_operationRequireHashable(arg)))
         }
 
-        public nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable {
+        public nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable, Sendable {
           let arg: Int
-          public var path: OperationCore.OperationPath {
-          OperationCore.OperationPath(self)
-          }
+
           public func mutate(
             isolation: isolated (any Actor)?,
             with arguments: Void,
@@ -865,14 +827,12 @@ extension BaseTestSuite {
         }
 
         private nonisolated func $something(arg: Int) -> __macro_local_9somethingfMu_ {
-          __macro_local_9somethingfMu_(arg: arg)
+          __macro_local_9somethingfMu_(arg: _operationRequireHashable(_operationRequireSendable(arg)))
         }
 
-        private nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable {
+        private nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable, Sendable {
           let arg: Int
-          var path: OperationCore.OperationPath {
-          OperationCore.OperationPath(self)
-          }
+
           func mutate(
             isolation: isolated (any Actor)?,
             with arguments: Void,
@@ -898,14 +858,12 @@ extension BaseTestSuite {
         }
 
         fileprivate nonisolated func $something(arg: Int) -> __macro_local_9somethingfMu_ {
-          __macro_local_9somethingfMu_(arg: arg)
+          __macro_local_9somethingfMu_(arg: _operationRequireHashable(_operationRequireSendable(arg)))
         }
 
-        fileprivate nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable {
+        fileprivate nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable, Sendable {
           let arg: Int
-          fileprivate var path: OperationCore.OperationPath {
-          OperationCore.OperationPath(self)
-          }
+
           fileprivate func mutate(
             isolation: isolated (any Actor)?,
             with arguments: Void,
@@ -938,15 +896,13 @@ extension BaseTestSuite {
 
         @available(iOS 13.0, *)
         nonisolated func $something(arg: Int) -> __macro_local_9somethingfMu_ {
-          __macro_local_9somethingfMu_(arg: arg)
+          __macro_local_9somethingfMu_(arg: _operationRequireHashable(_operationRequireSendable(arg)))
         }
 
         @available(iOS 13.0, *)
-        nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable {
+        nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable, Sendable {
           let arg: Int
-          var path: OperationCore.OperationPath {
-          OperationCore.OperationPath(self)
-          }
+
           func mutate(
             isolation: isolated (any Actor)?,
             with arguments: Void,
@@ -979,16 +935,14 @@ extension BaseTestSuite {
         @available(iOS 13.0, *)
         @available(tvOS 13.0, *)
         nonisolated func $something(arg: Int) -> __macro_local_9somethingfMu_ {
-          __macro_local_9somethingfMu_(arg: arg)
+          __macro_local_9somethingfMu_(arg: _operationRequireSendable(_operationRequireHashable(arg)))
         }
 
         @available(iOS 13.0, *)
         @available(tvOS 13.0, *)
-        nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable {
+        nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable, Sendable {
           let arg: Int
-          var path: OperationCore.OperationPath {
-          OperationCore.OperationPath(self)
-          }
+
           func mutate(
             isolation: isolated (any Actor)?,
             with arguments: Void,
@@ -1030,14 +984,12 @@ extension BaseTestSuite {
         }
 
         nonisolated func $something(arg: Int,) -> __macro_local_9somethingfMu_ {
-          __macro_local_9somethingfMu_(arg: arg)
+          __macro_local_9somethingfMu_(arg: _operationRequireSendable(_operationRequireHashable(arg)))
         }
 
-        nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable {
+        nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable, Sendable {
           let arg: Int
-          var path: OperationCore.OperationPath {
-          OperationCore.OperationPath(self)
-          }
+
           func mutate(
             isolation: isolated (any Actor)?,
             with arguments: Void,
@@ -1082,14 +1034,12 @@ extension BaseTestSuite {
         }
 
         nonisolated func $something(arg: Int,) -> __macro_local_9somethingfMu_ {
-          __macro_local_9somethingfMu_(arg: arg)
+          __macro_local_9somethingfMu_(arg: _operationRequireSendable(_operationRequireHashable(arg)))
         }
 
-        nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable {
+        nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable, Sendable {
           let arg: Int
-          var path: OperationCore.OperationPath {
-          OperationCore.OperationPath(self)
-          }
+
           func mutate(
             isolation: isolated (any Actor)?,
             with arguments: Void,
@@ -1131,14 +1081,12 @@ extension BaseTestSuite {
         }
 
         nonisolated func $something(arg: Int,) -> __macro_local_9somethingfMu_ {
-          __macro_local_9somethingfMu_(arg: arg)
+          __macro_local_9somethingfMu_(arg: _operationRequireSendable(_operationRequireHashable(arg)))
         }
 
-        nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable {
+        nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable, Sendable {
           let arg: Int
-          var path: OperationCore.OperationPath {
-          OperationCore.OperationPath(self)
-          }
+
           func mutate(
             isolation: isolated (any Actor)?,
             with arguments: Void,
@@ -1183,14 +1131,12 @@ extension BaseTestSuite {
         }
 
         nonisolated func $something(arg: Int,) -> __macro_local_9somethingfMu_ {
-          __macro_local_9somethingfMu_(arg: arg)
+          __macro_local_9somethingfMu_(arg: _operationRequireSendable(_operationRequireHashable(arg)))
         }
 
-        nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable {
+        nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable, Sendable {
           let arg: Int
-          var path: OperationCore.OperationPath {
-          OperationCore.OperationPath(self)
-          }
+
           func mutate(
             isolation: isolated (any Actor)?,
             with arguments: Void,
@@ -1223,11 +1169,9 @@ extension BaseTestSuite {
           __macro_local_9somethingfMu_<T>()
         }
 
-        nonisolated struct __macro_local_9somethingfMu_<T: Creatable>: OperationCore.MutationRequest, Hashable {
+        nonisolated struct __macro_local_9somethingfMu_<T: Creatable>: OperationCore.MutationRequest, Hashable, Sendable {
 
-          var path: OperationCore.OperationPath {
-          OperationCore.OperationPath(self)
-          }
+
           func mutate(
             isolation: isolated (any Actor)?,
             with arguments: Void,
@@ -1256,11 +1200,9 @@ extension BaseTestSuite {
           __macro_local_9somethingfMu_<T>()
         }
 
-        nonisolated struct __macro_local_9somethingfMu_<T: Creatable>: OperationCore.MutationRequest, Hashable {
+        nonisolated struct __macro_local_9somethingfMu_<T: Creatable>: OperationCore.MutationRequest, Hashable, Sendable {
 
-          var path: OperationCore.OperationPath {
-          OperationCore.OperationPath(self)
-          }
+
           func mutate(
             isolation: isolated (any Actor)?,
             with arguments: Void,
@@ -1371,14 +1313,12 @@ extension BaseTestSuite {
         }
 
         nonisolated func $something(id: Int) -> __macro_local_9somethingfMu_ {
-          __macro_local_9somethingfMu_(id: id)
+          __macro_local_9somethingfMu_(id: _operationRequireSendable(_operationRequireHashable(id)))
         }
 
         nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Identifiable {
           let id: Int
-          var path: OperationCore.OperationPath {
-          OperationCore.OperationPath(id)
-          }
+
           func mutate(
             isolation: isolated (any Actor)?,
             with arguments: Void,
@@ -1749,11 +1689,9 @@ extension BaseTestSuite {
           __macro_local_9somethingfMu_()
         }
 
-        nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable {
+        nonisolated struct __macro_local_9somethingfMu_: OperationCore.MutationRequest, Hashable, Sendable {
 
-          var path: OperationCore.OperationPath {
-          OperationCore.OperationPath(self)
-          }
+
           func mutate(
             isolation: isolated (any Actor)?,
             with arguments: Void,

--- a/Tests/OperationMacrosTests/QueryRequestMacroTests.swift
+++ b/Tests/OperationMacrosTests/QueryRequestMacroTests.swift
@@ -159,7 +159,7 @@ extension BaseTestSuite {
         }
 
         nonisolated func $something(arg: Int = 0) -> __macro_local_9somethingfMu_ {
-          __macro_local_9somethingfMu_(arg: _operationRequireHashable(_operationRequireSendable(arg)))
+          __macro_local_9somethingfMu_(arg: _operationRequireSendable(_operationRequireHashable(arg)))
         }
 
         nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable, Sendable {
@@ -492,7 +492,7 @@ extension BaseTestSuite {
           }
 
           static nonisolated func $something(arg: Int) -> __macro_local_9somethingfMu_ {
-            __macro_local_9somethingfMu_(arg: _operationRequireHashable(_operationRequireSendable(arg)), __macro_local_4typefMu_: _OperationHashableMetatype(type: Foo.self))
+            __macro_local_9somethingfMu_(arg: _operationRequireSendable(_operationRequireHashable(arg)), __macro_local_4typefMu_: _OperationHashableMetatype(type: Foo.self))
           }
 
           nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable, Sendable {
@@ -534,7 +534,7 @@ extension BaseTestSuite {
           }
 
           nonisolated func $something(arg: Int) -> __macro_local_9somethingfMu_ {
-            __macro_local_9somethingfMu_(arg: _operationRequireHashable(_operationRequireSendable(arg)), __macro_local_4typefMu_: self)
+            __macro_local_9somethingfMu_(arg: _operationRequireSendable(_operationRequireHashable(arg)), __macro_local_4typefMu_: self)
           }
 
           nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable, Sendable {
@@ -661,7 +661,7 @@ extension BaseTestSuite {
             }
 
             nonisolated func $something(arg: Int) -> __macro_local_9somethingfMu_ {
-              __macro_local_9somethingfMu_(arg: _operationRequireHashable(_operationRequireSendable(arg)), __macro_local_4typefMu_: self)
+              __macro_local_9somethingfMu_(arg: _operationRequireSendable(_operationRequireHashable(arg)), __macro_local_4typefMu_: self)
             }
 
             nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable, Sendable {
@@ -758,7 +758,7 @@ extension BaseTestSuite {
         }
 
         fileprivate nonisolated func $something(arg: Int) -> __macro_local_9somethingfMu_ {
-          __macro_local_9somethingfMu_(arg: _operationRequireHashable(_operationRequireSendable(arg)))
+          __macro_local_9somethingfMu_(arg: _operationRequireSendable(_operationRequireHashable(arg)))
         }
 
         fileprivate nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable, Sendable {
@@ -795,7 +795,7 @@ extension BaseTestSuite {
 
         @available(iOS 13.0, *)
         nonisolated func $something(arg: Int) -> __macro_local_9somethingfMu_ {
-          __macro_local_9somethingfMu_(arg: _operationRequireHashable(_operationRequireSendable(arg)))
+          __macro_local_9somethingfMu_(arg: _operationRequireSendable(_operationRequireHashable(arg)))
         }
 
         @available(iOS 13.0, *)

--- a/Tests/OperationMacrosTests/QueryRequestMacroTests.swift
+++ b/Tests/OperationMacrosTests/QueryRequestMacroTests.swift
@@ -24,11 +24,9 @@ extension BaseTestSuite {
           __macro_local_9somethingfMu_()
         }
 
-        nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable {
+        nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable, Sendable {
 
-          var path: OperationCore.OperationPath {
-          OperationCore.OperationPath(self)
-          }
+
           func fetch(
             isolation: isolated (any Actor)?,
             in context: OperationCore.OperationContext,
@@ -60,11 +58,9 @@ extension BaseTestSuite {
           __macro_local_9somethingfMu_()
         }
 
-        nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable {
+        nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable, Sendable {
 
-          var path: OperationCore.OperationPath {
-          OperationCore.OperationPath(self)
-          }
+
           func fetch(
             isolation: isolated (any Actor)?,
             in context: OperationCore.OperationContext,
@@ -93,15 +89,13 @@ extension BaseTestSuite {
         }
 
         nonisolated func $something(arg: Int, with arg2: String) -> __macro_local_9somethingfMu_ {
-          __macro_local_9somethingfMu_(arg: arg, arg2: arg2)
+          __macro_local_9somethingfMu_(arg: _operationRequireSendable(_operationRequireHashable(arg)), arg2: _operationRequireSendable(_operationRequireHashable(arg2)))
         }
 
-        nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable {
+        nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable, Sendable {
           let arg: Int
           let arg2: String
-          var path: OperationCore.OperationPath {
-          OperationCore.OperationPath(self)
-          }
+
           func fetch(
             isolation: isolated (any Actor)?,
             in context: OperationCore.OperationContext,
@@ -130,15 +124,13 @@ extension BaseTestSuite {
         }
 
         nonisolated func $something(with arg: Int, with arg2: String) -> __macro_local_9somethingfMu_ {
-          __macro_local_9somethingfMu_(arg: arg, arg2: arg2)
+          __macro_local_9somethingfMu_(arg: _operationRequireSendable(_operationRequireHashable(arg)), arg2: _operationRequireSendable(_operationRequireHashable(arg2)))
         }
 
-        nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable {
+        nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable, Sendable {
           let arg: Int
           let arg2: String
-          var path: OperationCore.OperationPath {
-          OperationCore.OperationPath(self)
-          }
+
           func fetch(
             isolation: isolated (any Actor)?,
             in context: OperationCore.OperationContext,
@@ -167,14 +159,12 @@ extension BaseTestSuite {
         }
 
         nonisolated func $something(arg: Int = 0) -> __macro_local_9somethingfMu_ {
-          __macro_local_9somethingfMu_(arg: arg)
+          __macro_local_9somethingfMu_(arg: _operationRequireHashable(_operationRequireSendable(arg)))
         }
 
-        nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable {
+        nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable, Sendable {
           let arg: Int
-          var path: OperationCore.OperationPath {
-          OperationCore.OperationPath(self)
-          }
+
           func fetch(
             isolation: isolated (any Actor)?,
             in context: OperationCore.OperationContext,
@@ -251,14 +241,12 @@ extension BaseTestSuite {
         }
 
         nonisolated func $something(arg: Int,) -> __macro_local_9somethingfMu_ {
-          __macro_local_9somethingfMu_(arg: arg)
+          __macro_local_9somethingfMu_(arg: _operationRequireSendable(_operationRequireHashable(arg)))
         }
 
-        nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable {
+        nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable, Sendable {
           let arg: Int
-          var path: OperationCore.OperationPath {
-          OperationCore.OperationPath(self)
-          }
+
           func fetch(
             isolation: isolated (any Actor)?,
             in context: OperationCore.OperationContext,
@@ -295,14 +283,12 @@ extension BaseTestSuite {
         }
 
         nonisolated func $something(arg: Int,) -> __macro_local_9somethingfMu_ {
-          __macro_local_9somethingfMu_(arg: arg)
+          __macro_local_9somethingfMu_(arg: _operationRequireSendable(_operationRequireHashable(arg)))
         }
 
-        nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable {
+        nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable, Sendable {
           let arg: Int
-          var path: OperationCore.OperationPath {
-          OperationCore.OperationPath(self)
-          }
+
           func fetch(
             isolation: isolated (any Actor)?,
             in context: OperationCore.OperationContext,
@@ -341,14 +327,12 @@ extension BaseTestSuite {
         }
 
         nonisolated func $something(arg: Int,) -> __macro_local_9somethingfMu_ {
-          __macro_local_9somethingfMu_(arg: arg)
+          __macro_local_9somethingfMu_(arg: _operationRequireSendable(_operationRequireHashable(arg)))
         }
 
-        nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable {
+        nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable, Sendable {
           let arg: Int
-          var path: OperationCore.OperationPath {
-          OperationCore.OperationPath(self)
-          }
+
           func fetch(
             isolation: isolated (any Actor)?,
             in context: OperationCore.OperationContext,
@@ -388,11 +372,9 @@ extension BaseTestSuite {
           __macro_local_9somethingfMu_()
         }
 
-        nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable {
+        nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable, Sendable {
 
-          var path: OperationCore.OperationPath {
-          OperationCore.OperationPath(self)
-          }
+
           func fetch(
             isolation: isolated (any Actor)?,
             in context: OperationCore.OperationContext,
@@ -424,15 +406,13 @@ extension BaseTestSuite {
           }
 
           static nonisolated func $something(arg: Int) -> __macro_local_9somethingfMu_ {
-            __macro_local_9somethingfMu_(arg: arg, __macro_local_4typefMu_: _OperationHashableMetatype(type: Foo.self))
+            __macro_local_9somethingfMu_(arg: _operationRequireSendable(_operationRequireHashable(arg)), __macro_local_4typefMu_: _OperationHashableMetatype(type: Foo.self))
           }
 
-          nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable {
+          nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable, Sendable {
             let arg: Int
             let __macro_local_4typefMu_: _OperationHashableMetatype<Foo>
-            var path: OperationCore.OperationPath {
-            OperationCore.OperationPath(self)
-            }
+
             func fetch(
               isolation: isolated (any Actor)?,
               in context: OperationCore.OperationContext,
@@ -471,11 +451,9 @@ extension BaseTestSuite {
             __macro_local_9somethingfMu_(__macro_local_4typefMu_: _OperationHashableMetatype(type: Foo.self))
           }
 
-          nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable {
+          nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable, Sendable {
             let __macro_local_4typefMu_: _OperationHashableMetatype<Foo>
-            var path: OperationCore.OperationPath {
-            OperationCore.OperationPath(self)
-            }
+
             func fetch(
               isolation: isolated (any Actor)?,
               in context: OperationCore.OperationContext,
@@ -514,15 +492,13 @@ extension BaseTestSuite {
           }
 
           static nonisolated func $something(arg: Int) -> __macro_local_9somethingfMu_ {
-            __macro_local_9somethingfMu_(arg: arg, __macro_local_4typefMu_: _OperationHashableMetatype(type: Foo.self))
+            __macro_local_9somethingfMu_(arg: _operationRequireHashable(_operationRequireSendable(arg)), __macro_local_4typefMu_: _OperationHashableMetatype(type: Foo.self))
           }
 
-          nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable {
+          nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable, Sendable {
             let arg: Int
             let __macro_local_4typefMu_: _OperationHashableMetatype<Foo>
-            var path: OperationCore.OperationPath {
-            OperationCore.OperationPath(self)
-            }
+
             func fetch(
               isolation: isolated (any Actor)?,
               in context: OperationCore.OperationContext,
@@ -558,15 +534,13 @@ extension BaseTestSuite {
           }
 
           nonisolated func $something(arg: Int) -> __macro_local_9somethingfMu_ {
-            __macro_local_9somethingfMu_(arg: arg, __macro_local_4typefMu_: self)
+            __macro_local_9somethingfMu_(arg: _operationRequireHashable(_operationRequireSendable(arg)), __macro_local_4typefMu_: self)
           }
 
-          nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable {
+          nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable, Sendable {
             let arg: Int
             let __macro_local_4typefMu_: Foo
-            var path: OperationCore.OperationPath {
-            OperationCore.OperationPath(self)
-            }
+
             func fetch(
               isolation: isolated (any Actor)?,
               in context: OperationCore.OperationContext,
@@ -607,15 +581,13 @@ extension BaseTestSuite {
           }
 
           nonisolated func $something(arg: Int) -> __macro_local_9somethingfMu_ {
-            __macro_local_9somethingfMu_(arg: arg, __macro_local_4typefMu_: self)
+            __macro_local_9somethingfMu_(arg: _operationRequireSendable(_operationRequireHashable(arg)), __macro_local_4typefMu_: self)
           }
 
-          nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable {
+          nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable, Sendable {
             let arg: Int
             let __macro_local_4typefMu_: Foo
-            var path: OperationCore.OperationPath {
-            OperationCore.OperationPath(self)
-            }
+
             func fetch(
               isolation: isolated (any Actor)?,
               in context: OperationCore.OperationContext,
@@ -648,14 +620,12 @@ extension BaseTestSuite {
           }
 
           nonisolated func $something(arg: Int) -> __macro_local_9somethingfMu_ {
-            __macro_local_9somethingfMu_(arg: arg)
+            __macro_local_9somethingfMu_(arg: _operationRequireSendable(_operationRequireHashable(arg)))
           }
 
-          nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable {
+          nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable, Sendable {
             let arg: Int
-            var path: OperationCore.OperationPath {
-            OperationCore.OperationPath(self)
-            }
+
             func fetch(
               isolation: isolated (any Actor)?,
               in context: OperationCore.OperationContext,
@@ -691,15 +661,13 @@ extension BaseTestSuite {
             }
 
             nonisolated func $something(arg: Int) -> __macro_local_9somethingfMu_ {
-              __macro_local_9somethingfMu_(arg: arg, __macro_local_4typefMu_: self)
+              __macro_local_9somethingfMu_(arg: _operationRequireHashable(_operationRequireSendable(arg)), __macro_local_4typefMu_: self)
             }
 
-            nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable {
+            nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable, Sendable {
               let arg: Int
               let __macro_local_4typefMu_: Foo
-              var path: OperationCore.OperationPath {
-              OperationCore.OperationPath(self)
-              }
+
               func fetch(
                 isolation: isolated (any Actor)?,
                 in context: OperationCore.OperationContext,
@@ -730,14 +698,12 @@ extension BaseTestSuite {
         }
 
         public nonisolated func $something(arg: Int) -> __macro_local_9somethingfMu_ {
-          __macro_local_9somethingfMu_(arg: arg)
+          __macro_local_9somethingfMu_(arg: _operationRequireSendable(_operationRequireHashable(arg)))
         }
 
-        public nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable {
+        public nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable, Sendable {
           let arg: Int
-          public var path: OperationCore.OperationPath {
-          OperationCore.OperationPath(self)
-          }
+
           public func fetch(
             isolation: isolated (any Actor)?,
             in context: OperationCore.OperationContext,
@@ -762,14 +728,12 @@ extension BaseTestSuite {
         }
 
         private nonisolated func $something(arg: Int) -> __macro_local_9somethingfMu_ {
-          __macro_local_9somethingfMu_(arg: arg)
+          __macro_local_9somethingfMu_(arg: _operationRequireSendable(_operationRequireHashable(arg)))
         }
 
-        private nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable {
+        private nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable, Sendable {
           let arg: Int
-          var path: OperationCore.OperationPath {
-          OperationCore.OperationPath(self)
-          }
+
           func fetch(
             isolation: isolated (any Actor)?,
             in context: OperationCore.OperationContext,
@@ -794,14 +758,12 @@ extension BaseTestSuite {
         }
 
         fileprivate nonisolated func $something(arg: Int) -> __macro_local_9somethingfMu_ {
-          __macro_local_9somethingfMu_(arg: arg)
+          __macro_local_9somethingfMu_(arg: _operationRequireHashable(_operationRequireSendable(arg)))
         }
 
-        fileprivate nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable {
+        fileprivate nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable, Sendable {
           let arg: Int
-          fileprivate var path: OperationCore.OperationPath {
-          OperationCore.OperationPath(self)
-          }
+
           fileprivate func fetch(
             isolation: isolated (any Actor)?,
             in context: OperationCore.OperationContext,
@@ -833,15 +795,13 @@ extension BaseTestSuite {
 
         @available(iOS 13.0, *)
         nonisolated func $something(arg: Int) -> __macro_local_9somethingfMu_ {
-          __macro_local_9somethingfMu_(arg: arg)
+          __macro_local_9somethingfMu_(arg: _operationRequireHashable(_operationRequireSendable(arg)))
         }
 
         @available(iOS 13.0, *)
-        nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable {
+        nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable, Sendable {
           let arg: Int
-          var path: OperationCore.OperationPath {
-          OperationCore.OperationPath(self)
-          }
+
           func fetch(
             isolation: isolated (any Actor)?,
             in context: OperationCore.OperationContext,
@@ -873,16 +833,14 @@ extension BaseTestSuite {
         @available(iOS 13.0, *)
         @available(tvOS 13.0, *)
         nonisolated func $something(arg: Int) -> __macro_local_9somethingfMu_ {
-          __macro_local_9somethingfMu_(arg: arg)
+          __macro_local_9somethingfMu_(arg: _operationRequireSendable(_operationRequireHashable(arg)))
         }
 
         @available(iOS 13.0, *)
         @available(tvOS 13.0, *)
-        nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable {
+        nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable, Sendable {
           let arg: Int
-          var path: OperationCore.OperationPath {
-          OperationCore.OperationPath(self)
-          }
+
           func fetch(
             isolation: isolated (any Actor)?,
             in context: OperationCore.OperationContext,
@@ -923,14 +881,12 @@ extension BaseTestSuite {
         }
 
         nonisolated func $something(arg: Int,) -> __macro_local_9somethingfMu_ {
-          __macro_local_9somethingfMu_(arg: arg)
+          __macro_local_9somethingfMu_(arg: _operationRequireSendable(_operationRequireHashable(arg)))
         }
 
-        nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable {
+        nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable, Sendable {
           let arg: Int
-          var path: OperationCore.OperationPath {
-          OperationCore.OperationPath(self)
-          }
+
           func fetch(
             isolation: isolated (any Actor)?,
             in context: OperationCore.OperationContext,
@@ -970,14 +926,12 @@ extension BaseTestSuite {
         }
 
         nonisolated func $something(arg: Int,) -> __macro_local_9somethingfMu_ {
-          __macro_local_9somethingfMu_(arg: arg)
+          __macro_local_9somethingfMu_(arg: _operationRequireSendable(_operationRequireHashable(arg)))
         }
 
-        nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable {
+        nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable, Sendable {
           let arg: Int
-          var path: OperationCore.OperationPath {
-          OperationCore.OperationPath(self)
-          }
+
           func fetch(
             isolation: isolated (any Actor)?,
             in context: OperationCore.OperationContext,
@@ -1014,14 +968,12 @@ extension BaseTestSuite {
         }
 
         nonisolated func $something(arg: Int,) -> __macro_local_9somethingfMu_ {
-          __macro_local_9somethingfMu_(arg: arg)
+          __macro_local_9somethingfMu_(arg: _operationRequireSendable(_operationRequireHashable(arg)))
         }
 
-        nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable {
+        nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable, Sendable {
           let arg: Int
-          var path: OperationCore.OperationPath {
-          OperationCore.OperationPath(self)
-          }
+
           func fetch(
             isolation: isolated (any Actor)?,
             in context: OperationCore.OperationContext,
@@ -1061,14 +1013,12 @@ extension BaseTestSuite {
         }
 
         nonisolated func $something(arg: Int,) -> __macro_local_9somethingfMu_ {
-          __macro_local_9somethingfMu_(arg: arg)
+          __macro_local_9somethingfMu_(arg: _operationRequireSendable(_operationRequireHashable(arg)))
         }
 
-        nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable {
+        nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable, Sendable {
           let arg: Int
-          var path: OperationCore.OperationPath {
-          OperationCore.OperationPath(self)
-          }
+
           func fetch(
             isolation: isolated (any Actor)?,
             in context: OperationCore.OperationContext,
@@ -1100,11 +1050,9 @@ extension BaseTestSuite {
           __macro_local_9somethingfMu_<T>()
         }
 
-        nonisolated struct __macro_local_9somethingfMu_<T: Creatable>: OperationCore.QueryRequest, Hashable {
+        nonisolated struct __macro_local_9somethingfMu_<T: Creatable>: OperationCore.QueryRequest, Hashable, Sendable {
 
-          var path: OperationCore.OperationPath {
-          OperationCore.OperationPath(self)
-          }
+
           func fetch(
             isolation: isolated (any Actor)?,
             in context: OperationCore.OperationContext,
@@ -1132,11 +1080,9 @@ extension BaseTestSuite {
           __macro_local_9somethingfMu_<T>()
         }
 
-        nonisolated struct __macro_local_9somethingfMu_<T: Creatable>: OperationCore.QueryRequest, Hashable {
+        nonisolated struct __macro_local_9somethingfMu_<T: Creatable>: OperationCore.QueryRequest, Hashable, Sendable {
 
-          var path: OperationCore.OperationPath {
-          OperationCore.OperationPath(self)
-          }
+
           func fetch(
             isolation: isolated (any Actor)?,
             in context: OperationCore.OperationContext,
@@ -1246,14 +1192,12 @@ extension BaseTestSuite {
         }
 
         nonisolated func $something(id: Int) -> __macro_local_9somethingfMu_ {
-          __macro_local_9somethingfMu_(id: id)
+          __macro_local_9somethingfMu_(id: _operationRequireSendable(_operationRequireHashable(id)))
         }
 
         nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Identifiable {
           let id: Int
-          var path: OperationCore.OperationPath {
-          OperationCore.OperationPath(id)
-          }
+
           func fetch(
             isolation: isolated (any Actor)?,
             in context: OperationCore.OperationContext,
@@ -1579,11 +1523,9 @@ extension BaseTestSuite {
           __macro_local_9somethingfMu_()
         }
 
-        nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable {
+        nonisolated struct __macro_local_9somethingfMu_: OperationCore.QueryRequest, Hashable, Sendable {
 
-          var path: OperationCore.OperationPath {
-          OperationCore.OperationPath(self)
-          }
+
           func fetch(
             isolation: isolated (any Actor)?,
             in context: OperationCore.OperationContext,


### PR DESCRIPTION
For various `OperationPath` synthesized requirements, we'll need certain arguments to conform to Hashable or Sendable respectively. We can present non-conformant related compiler error messages nicely if we wrap them in a dedicated type checker function (eg. `_operationRequireHashable`).

If the caller chooses to infer the path requirement via Identifiable, these type checks are performed only for the `id` argument. The default path synthesis is to infer from Hashable, which requires Hashable and Sendable type checks for all argument to ensure that the generated struct retains its synthesized conformance to both Hashable and Sendable.

This also gets rid of many Sendable-related warning messages that were present in the macro generated code.