### PR TITLE
`#run` Macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,39 @@ func sendFriendRequestMutation(
 > [!NOTE]
 > To learn more about advanced state management practices including pattern matching using the `OperationPath` type, similar to [Tanstack Query’s query key](https://tanstack.com/query/latest/docs/framework/react/guides/query-keys) pattern matching, checkout [PatternMatchingAndStateManagement](https://swiftpackageindex.com/mhayes853/swift-operation/main/documentation/operationcore/patternmatchingandstatemanagement).
 
+### Stateless Operations
+
+If your operation does not need managed state, use `@OperationRequest` and run it directly with `#run`.
+
+```swift
+import Operation
+
+@OperationRequest
+func myOperation(
+  context: OperationContext,
+  continuation: OperationContinuation<Int, any Error>
+) async throws -> Int {
+  continuation.yield(someValue())
+  return someOtherValue()
+}
+
+let value = try await #run($myOperation)
+
+var context = OperationContext()
+let previewValue = try await #run($myOperation, context: context)
+
+let continuation = OperationContinuation<Int, any Error> { result, context in
+  // Handle intermittent results.
+}
+let streamedValue = try await #run(
+  $myOperation,
+  context: context,
+  continuation: continuation
+)
+```
+
+Queries, mutations, and paginated operations generally run through `OperationStore` because they manage state.
+
 ## Traits
 The library ships with a handful of package traits, which allow you to conditionally compile dependencies and features of the library. You can learn more about package traits from reading the official evolution [proposal](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0450-swiftpm-package-traits.md).
 - `SwiftOperationLogging` - Adds swift-log support to the library, including a `Logger` context property and the `logDuration` modifier.

--- a/Sources/Operation/Macros.swift
+++ b/Sources/Operation/Macros.swift
@@ -50,6 +50,24 @@ public macro MutationRequest(
   path: _OperationPathMacroSynthesizer = .inferredFromHashable
 ) = #externalMacro(module: "OperationMacros", type: "MutationRequestMacro")
 
+/// Runs an operation by constructing an `OperationRunner` and invoking `run`.
+///
+/// ```swift
+/// @OperationRequest
+/// func myOperation() async throws -> Int {
+///   42
+/// }
+///
+/// let value = try await #run($myOperation)
+/// ```
+@freestanding(expression)
+public macro run<Operation: OperationRequest>(
+  _ operation: Operation,
+  context: OperationContext = OperationContext(),
+  continuation: OperationContinuation<Operation.Value, Operation.Failure> =
+    OperationContinuation { _, _ in }
+) -> Operation.Value = #externalMacro(module: "OperationMacros", type: "RunMacro")
+
 // MARK: - _OperationPathMacroSynthesizer
 
 public struct _OperationPathMacroSynthesizer: Sendable {

--- a/Sources/OperationCore/Documentation.docc/OperationCore.md
+++ b/Sources/OperationCore/Documentation.docc/OperationCore.md
@@ -350,6 +350,39 @@ func sendFriendRequestMutation(
 ```
 > Note: To learn more about advanced state management practices including pattern matching using the ``OperationPath`` type, similar to [Tanstack Query’s query key](https://tanstack.com/query/latest/docs/framework/react/guides/query-keys) pattern matching, checkout <doc:PatternMatchingAndStateManagement>.
 
+### Stateless Operations
+
+If your operation does not need managed state, use `@OperationRequest` and run it directly with `#run`.
+
+```swift
+import Operation
+
+@OperationRequest
+func myOperation(
+  context: OperationContext,
+  continuation: OperationContinuation<Int, any Error>
+) async throws -> Int {
+  continuation.yield(someValue())
+  return someOtherValue()
+}
+
+let value = try await #run($myOperation)
+
+var context = OperationContext()
+let previewValue = try await #run($myOperation, context: context)
+
+let continuation = OperationContinuation<Int, any Error> { result, context in
+  // Handle intermittent results.
+}
+let streamedValue = try await #run(
+  $myOperation,
+  context: context,
+  continuation: continuation
+)
+```
+
+Queries, mutations, and paginated operations generally run through `OperationStore` because they manage state.
+
 ## Traits
 The library ships with a handful of package traits, which allow you to conditionally compile dependencies and features of the library. You can learn more about package traits from reading the official evolution [proposal](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0450-swiftpm-package-traits.md).
 - `SwiftOperationLogging` - Adds swift-log support to the library, including a `Logger` context property and the `logDuration` modifier.

--- a/Sources/OperationCore/OperationRunner.swift
+++ b/Sources/OperationCore/OperationRunner.swift
@@ -1,15 +1,20 @@
 /// A simple runtime for an ``OperationRequest``.
 ///
+/// You will primarily use this runtime through the `#run` macro, which constructs an
+/// `OperationRunner` and invokes ``run(isolation:in:with:)`` for you.
+///
 /// ```swift
 /// @OperationRequest
 /// func myOperation() async throws -> Value {
 ///   // ...
 /// }
 ///
-/// let runner = OperationRunner(operation: $myOperation)
-/// let value = try await runner.run()
+/// let value = try await #run($myOperation)
 ///
-/// // ...
+/// // You can still construct a runner manually for advanced control.
+/// let runner = OperationRunner(operation: $myOperation)
+/// runner.context = OperationContext()
+/// let valueWithCustomContext = try await runner.run()
 /// ```
 ///
 /// The runner makes sure to invoke ``OperationRequest/setup(context:)-8y79v`` once during

--- a/Sources/OperationMacros/Plugin.swift
+++ b/Sources/OperationMacros/Plugin.swift
@@ -7,6 +7,7 @@ struct OperationMacrosPlugin: CompilerPlugin {
     ContextEntryMacro.self,
     OperationRequestMacro.self,
     QueryRequestMacro.self,
-    MutationRequestMacro.self
+    MutationRequestMacro.self,
+    RunMacro.self
   ]
 }

--- a/Sources/OperationMacros/RunMacro.swift
+++ b/Sources/OperationMacros/RunMacro.swift
@@ -1,0 +1,33 @@
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+public enum RunMacro: ExpressionMacro {
+  public static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> ExprSyntax {
+    let arguments = Array(node.arguments)
+
+    let operation = arguments[0].expression.trimmedDescription
+    let initialContext =
+      arguments.count >= 2
+      ? arguments[1].expression.trimmedDescription
+      : "OperationCore.OperationContext()"
+    let continuation =
+      arguments.count >= 3
+      ? arguments[2].expression.trimmedDescription
+      : "OperationCore.OperationContinuation { _, _ in }"
+
+    return """
+      OperationCore.OperationRunner(
+        operation: \(raw: operation),
+        initialContext: \(raw: initialContext)
+      ).run(with: \(raw: continuation))
+      """
+  }
+
+  private static func invalidExpansion() -> ExprSyntax {
+    "fatalError(\"Invalid #run macro invocation\")"
+  }
+}

--- a/Tests/OperationMacrosTests/BaseTestSuite.swift
+++ b/Tests/OperationMacrosTests/BaseTestSuite.swift
@@ -12,7 +12,8 @@
         "ContextEntry": ContextEntryMacro.self,
         "OperationRequest": OperationRequestMacro.self,
         "QueryRequest": QueryRequestMacro.self,
-        "MutationRequest": MutationRequestMacro.self
+        "MutationRequest": MutationRequestMacro.self,
+        "run": RunMacro.self
       ],
       record: .failed
     )

--- a/Tests/OperationMacrosTests/RunMacroTests.swift
+++ b/Tests/OperationMacrosTests/RunMacroTests.swift
@@ -1,0 +1,78 @@
+import MacroTesting
+import OperationMacros
+import Testing
+
+extension BaseTestSuite {
+  @Suite("RunMacro tests")
+  struct RunMacroTests {
+    @Test("Run With Defaults")
+    func runWithDefaults() {
+      assertMacro {
+        """
+        func run(operation: some OperationRequest<Int, Never>) async {
+          _ = await #run(operation)
+        }
+        """
+      } expansion: {
+        """
+        func run(operation: some OperationRequest<Int, Never>) async {
+          _ = await OperationCore.OperationRunner(
+            operation: operation,
+            initialContext: OperationCore.OperationContext()
+          ).run(with: OperationCore.OperationContinuation { _, _ in
+            })
+        }
+        """
+      }
+    }
+
+    @Test("Run With Context")
+    func runWithContext() {
+      assertMacro {
+        """
+        func run(operation: some OperationRequest<Int, Never>, context: OperationContext) async {
+          _ = await #run(operation, context: context)
+        }
+        """
+      } expansion: {
+        """
+        func run(operation: some OperationRequest<Int, Never>, context: OperationContext) async {
+          _ = await OperationCore.OperationRunner(
+            operation: operation,
+            initialContext: context
+          ).run(with: OperationCore.OperationContinuation { _, _ in
+            })
+        }
+        """
+      }
+    }
+
+    @Test("Run With Context And Continuation")
+    func runWithContextAndContinuation() {
+      assertMacro {
+        """
+        func run(
+          operation: some OperationRequest<Int, Never>,
+          context: OperationContext,
+          continuation: OperationContinuation<Int, Never>
+        ) async {
+          _ = await #run(operation, context: context, continuation: continuation)
+        }
+        """
+      } expansion: {
+        """
+        func run(
+          operation: some OperationRequest<Int, Never>,
+          context: OperationContext,
+          continuation: OperationContinuation<Int, Never>
+        ) async {
+          _ = await OperationCore.OperationRunner(
+            operation: operation,
+            initialContext: context
+          ).run(with: continuation)
+        }
+        """
+      }
+    }
+  }
+}

--- a/Tests/OperationTests/RunMacroTests.swift
+++ b/Tests/OperationTests/RunMacroTests.swift
@@ -1,0 +1,101 @@
+import CustomDump
+import Foundation
+import Operation
+import Testing
+
+@Suite("Run macro tests")
+struct RunMacroTests {
+  @Test("Runs With Defaults")
+  func runsWithDefaults() async {
+    let value = await #run($runMacroOperation)
+    expectNoDifference(value, 42)
+  }
+
+  @Test("Uses Provided Context")
+  func usesProvidedContext() async {
+    var context = OperationContext()
+    context.multiplier = 3
+
+    let value = await #run($runMacroContextOperation(input: 4), context: context)
+    expectNoDifference(value, 12)
+  }
+
+  @Test("Runs Setup Through OperationRunner")
+  func runsSetupThroughOperationRunner() async {
+    let value = await #run(SetupAwareOperation())
+    expectNoDifference(value, 7)
+  }
+
+  @Test("Uses Provided Continuation")
+  func usesProvidedContinuation() async {
+    let results = LockedBox<[Int]>([])
+    let continuation = OperationContinuation<Int, Never> { result, _ in
+      guard case let .success(value) = result else { return }
+      results.withLock { $0.append(value) }
+    }
+
+    let value = await #run(
+      $runMacroContinuationOperation,
+      context: OperationContext(),
+      continuation: continuation
+    )
+
+    expectNoDifference(value, 42)
+    expectNoDifference(results.value, [1, 2])
+  }
+}
+
+@OperationRequest
+private func runMacroOperation() -> Int {
+  42
+}
+
+@OperationRequest
+private func runMacroContextOperation(input: Int, context: OperationContext) -> Int {
+  input * context.multiplier
+}
+
+@OperationRequest
+private func runMacroContinuationOperation(continuation: OperationContinuation<Int, Never>) -> Int {
+  continuation.yield(1)
+  continuation.yield(2)
+  return 42
+}
+
+private struct SetupAwareOperation: OperationRequest {
+  func setup(context: inout OperationContext) {
+    context.setupValue = 7
+  }
+
+  func run(
+    isolation: isolated (any Actor)?,
+    in context: OperationContext,
+    with continuation: OperationContinuation<Int, Never>
+  ) async -> Int {
+    context.setupValue
+  }
+}
+
+extension OperationContext {
+  @ContextEntry fileprivate var multiplier = 1
+  @ContextEntry fileprivate var setupValue = 0
+}
+
+private final class LockedBox<Value>: @unchecked Sendable {
+  private let lock = NSLock()
+  private var _value: Value
+
+  init(_ value: Value) {
+    self._value = value
+  }
+
+  var value: Value {
+    self.withLock { $0 }
+  }
+
+  func withLock<R>(_ body: (inout Value) -> R) -> R {
+    self.lock.lock()
+    defer { self.lock.unlock() }
+    return body(&self._value)
+  }
+}


### PR DESCRIPTION
Introduces a `#run` macro to make running stateless operations more convenient.

eg.
```swift
@OperationRequest
func myOperation(
  context: OperationContext,
  continuation: OperationContinuation<Int, any Error>
) async throws -> Int {
  continuation.yield(someValue())
  return someOtherValue()
}

let value = try await #run($myOperation)
```