### PR TITLE
URLConnectionObserver

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -43,6 +43,7 @@ let package = Package(
     )
   ],
   dependencies: [
+    .package(url: "https://github.com/pointfreeco/swift-clocks", from: "1.0.6"),
     .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "1.9.3"),
     .package(url: "https://github.com/pointfreeco/swift-sharing", from: "2.7.0"),
     .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.3.3"),
@@ -169,6 +170,7 @@ let package = Package(
 var operationTestsDependencies: [Target.Dependency] = [
   "Operation",
   "OperationTestHelpers",
+  .product(name: "Clocks", package: "swift-clocks"),
   .product(name: "CustomDump", package: "swift-custom-dump"),
   .product(name: "IssueReportingTestSupport", package: "xctest-dynamic-overlay")
 ]

--- a/Sources/Operation/OperationClient+Defaults.swift
+++ b/Sources/Operation/OperationClient+Defaults.swift
@@ -179,7 +179,7 @@ extension OperationClient {
     #elseif SwiftOperationWebBrowser && canImport(JavaScriptKit)
       NavigatorOnlineObserver.shared
     #else
-      nil
+      URLConnectionObserver.startingShared()
     #endif
   }
 

--- a/Sources/OperationCore/Internal/AsyncTimerSequence.swift
+++ b/Sources/OperationCore/Internal/AsyncTimerSequence.swift
@@ -1,0 +1,83 @@
+#if (canImport(RegexBuilder) || !os(macOS) && !targetEnvironment(macCatalyst))
+  //===----------------------------------------------------------------------===//
+  //
+  // This source file is part of the Swift Async Algorithms open source project
+  //
+  // Copyright (c) 2022 Apple Inc. and the Swift project authors
+  // Licensed under Apache License v2.0 with Runtime Library Exception
+  //
+  // See https://swift.org/LICENSE.txt for license information
+  //
+  //===----------------------------------------------------------------------===//
+
+  /// An `AsyncSequence` that produces elements at regular intervals.
+  ///
+  /// Internal use only. Not meant to be used outside the library.
+  @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+  package struct _AsyncTimerSequence<C: Clock>: AsyncSequence {
+    package typealias Element = C.Instant
+
+    package struct Iterator: AsyncIteratorProtocol {
+      var clock: C?
+      let interval: C.Instant.Duration
+      let tolerance: C.Instant.Duration?
+      var last: C.Instant?
+
+      init(interval: C.Instant.Duration, tolerance: C.Instant.Duration?, clock: C) {
+        self.clock = clock
+        self.interval = interval
+        self.tolerance = tolerance
+      }
+
+      func nextDeadline(_ clock: C) -> C.Instant {
+        let now = clock.now
+        let last = self.last ?? now
+        let next = last.advanced(by: self.interval)
+        if next < now {
+          return last.advanced(
+            by: self.interval * Int(((next.duration(to: now)) / self.interval).rounded(.up))
+          )
+        } else {
+          return next
+        }
+      }
+
+      package mutating func next() async -> C.Instant? {
+        guard let clock = self.clock else {
+          return nil
+        }
+        let next = self.nextDeadline(clock)
+        do {
+          try await clock.sleep(until: next, tolerance: self.tolerance)
+        } catch {
+          self.clock = nil
+          return nil
+        }
+        let now = clock.now
+        self.last = next
+        return now
+      }
+    }
+
+    let clock: C
+    let interval: C.Instant.Duration
+    let tolerance: C.Instant.Duration?
+
+    /// Create an `AsyncTimerSequence` with a given repeating interval.
+    package init(interval: C.Instant.Duration, tolerance: C.Instant.Duration? = nil, clock: C) {
+      self.clock = clock
+      self.interval = interval
+      self.tolerance = tolerance
+    }
+
+    package func makeAsyncIterator() -> Iterator {
+      Iterator(interval: self.interval, tolerance: self.tolerance, clock: self.clock)
+    }
+  }
+
+  @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+  extension _AsyncTimerSequence: Sendable {}
+
+  @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+  extension _AsyncTimerSequence.Iterator: Sendable {}
+#endif

--- a/Sources/OperationCore/NetworkObserving/URLConnectionObserver.swift
+++ b/Sources/OperationCore/NetworkObserving/URLConnectionObserver.swift
@@ -1,0 +1,192 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+// MARK: - URLConnectionObserver
+
+/// A ``NetworkObserver`` that periodically pings a URL to infer network connectivity.
+///
+/// The observer periodically pings a URL to determine the current network connection status based
+/// on a `Duration` and `Clock` that you specify.
+@available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
+public final class URLConnectionObserver: NetworkObserver, Sendable {
+  private struct State: Sendable {
+    var currentStatus = NetworkConnectionStatus.connected
+    var task: Task<Void, Never>?
+  }
+
+  private let observe: @Sendable (URLConnectionObserver) async -> Void
+
+  private let state = Lock(State())
+  private let subscriptions = OperationSubscriptions<@Sendable (NetworkConnectionStatus) -> Void>()
+
+  /// True if the observer is actively pinging the URL.
+  public var isRunning: Bool {
+    self.state.withLock { $0.task != nil }
+  }
+
+  public init<C: Clock>(
+    session: URLSession = .operationConnectivity,
+    url: URL = .operationURLConnectionObserverDefault,
+    clock: C = ContinuousClock(),
+    pingingEvery interval: Duration = .seconds(120)
+  ) where C.Duration == Duration {
+    self.observe = { observer in
+      await observer.ping(to: url, using: session)
+      for await _ in _AsyncTimerSequence(interval: interval, clock: clock) {
+        await observer.ping(to: url, using: session)
+      }
+    }
+  }
+
+  /// Starts pinging the URL at the specified interval with the specified `URLSession` and `Clock`.
+  public func start() {
+    self.state.withLock {
+      $0.task?.cancel()
+      $0.task = Task { [weak self] in
+        guard let self else { return }
+        await self.observe(self)
+      }
+    }
+  }
+
+  /// Stops pinging the URL.
+  public func stop() {
+    self.state.withLock { state in
+      state.task?.cancel()
+      state.task = nil
+    }
+  }
+
+  deinit {
+    self.stop()
+  }
+
+  public var currentStatus: NetworkConnectionStatus {
+    self.state.withLock { $0.currentStatus }
+  }
+
+  public func subscribe(
+    with handler: @escaping @Sendable (NetworkConnectionStatus) -> Void
+  ) -> OperationSubscription {
+    let subscription = self.subscriptions.add(handler: handler).subscription
+    handler(self.currentStatus)
+    if !self.isRunning {
+      self.start()
+    }
+    return subscription
+  }
+
+  private func ping(to url: URL, using session: URLSession) async {
+    var request = URLRequest(url: url)
+    request.httpMethod = "HEAD"
+
+    let status = await self.status(for: request, using: session)
+
+    self.state.withLock { state in
+      guard status != state.currentStatus else { return }
+      state.currentStatus = status
+      self.subscriptions.forEach { $0(status) }
+    }
+  }
+
+  private func status(
+    for request: URLRequest,
+    using session: URLSession
+  ) async -> NetworkConnectionStatus {
+    do {
+      _ = try await session.data(for: request)
+      return .connected
+    } catch {
+      return .disconnected
+    }
+  }
+}
+
+// MARK: - Starting
+
+@available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
+extension URLConnectionObserver {
+  /// Creates an observer and starts pinging the URL.
+  ///
+  /// - Parameters:
+  ///   - session: The URL session to use for pinging.
+  ///   - url: The URL to ping.
+  ///   - clock: The clock to use for timing.
+  ///   - interval: The interval between pings.
+  /// - Returns: A running `URLConnectionObserver`.
+  public static func starting<C: Clock>(
+    session: URLSession = .operationConnectivity,
+    url: URL = .operationURLConnectionObserverDefault,
+    clock: C = ContinuousClock(),
+    pingingEvery interval: Duration = .seconds(120)
+  ) -> URLConnectionObserver where C.Duration == Duration {
+    let observer = URLConnectionObserver(
+      session: session,
+      url: url,
+      clock: clock,
+      pingingEvery: interval
+    )
+    observer.start()
+    return observer
+  }
+}
+
+// MARK: - Shared
+
+@available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
+extension URLConnectionObserver {
+  private static let _shared = Lock<URLConnectionObserver?>(nil)
+
+  /// A shared observer instance that pings the default URL.
+  public static var shared: URLConnectionObserver {
+    Self._shared.withLock { observer in
+      if let observer {
+        return observer
+      }
+      observer = URLConnectionObserver()
+      return observer!
+    }
+  }
+
+  /// Creates a shared observer instance and starts pinging the URL.
+  ///
+  /// ``isRunning`` will be true on the returned instance.
+  ///
+  /// - Returns: A shared instance of `URLConnectionObserver`.
+  public static func startingShared() -> URLConnectionObserver {
+    let shared = Self.shared
+    if !shared.isRunning {
+      shared.start()
+    }
+    return shared
+  }
+}
+
+// MARK: - Connectivity Helpers
+
+extension URLSession {
+  /// A URL session configured for use with ``URLConnectionObserver``.
+  public static let operationConnectivity: URLSession = {
+    let configuration = URLSessionConfiguration.default
+    configuration.timeoutIntervalForRequest = 5
+    configuration.allowsCellularAccess = true
+    configuration.allowsConstrainedNetworkAccess = true
+    configuration.allowsExpensiveNetworkAccess = true
+    configuration.httpCookieStorage = nil
+    configuration.urlCache = nil
+    if #available(watchOS 11.4, macOS 15.4, *) {
+      configuration.usesClassicLoadingMode = false
+    }
+    return URLSession(configuration: configuration)
+  }()
+}
+
+extension URL {
+  /// The default URL used by ``URLConnectionObserver`` to check the ``NetworkConnectionStatus``.
+  public static let operationURLConnectionObserverDefault = URL(
+    string: "https://www.apple.com/library/test/success.html"
+  )!
+}

--- a/Sources/OperationCore/NetworkObserving/URLConnectionObserver.swift
+++ b/Sources/OperationCore/NetworkObserving/URLConnectionObserver.swift
@@ -172,14 +172,16 @@ extension URLSession {
   public static let operationConnectivity: URLSession = {
     let configuration = URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = 5
-    configuration.allowsCellularAccess = true
-    configuration.allowsConstrainedNetworkAccess = true
-    configuration.allowsExpensiveNetworkAccess = true
     configuration.httpCookieStorage = nil
     configuration.urlCache = nil
-    if #available(watchOS 11.4, macOS 15.4, *) {
-      configuration.usesClassicLoadingMode = false
-    }
+    configuration.allowsCellularAccess = true
+    #if canImport(Darwin)
+      configuration.allowsConstrainedNetworkAccess = true
+      configuration.allowsExpensiveNetworkAccess = true
+      if #available(watchOS 11.4, macOS 15.4, iOS 18, tvOS 18, *) {
+        configuration.usesClassicLoadingMode = false
+      }
+    #endif
     return URLSession(configuration: configuration)
   }()
 }

--- a/Sources/OperationCore/NetworkObserving/URLConnectionObserver.swift
+++ b/Sources/OperationCore/NetworkObserving/URLConnectionObserver.swift
@@ -27,6 +27,13 @@ public final class URLConnectionObserver: NetworkObserver, Sendable {
     self.state.withLock { $0.task != nil }
   }
 
+  /// Creates an observer.
+  ///
+  /// - Parameters:
+  ///   - session: The `URLSession` to use for pinging.
+  ///   - url: The URL to ping.
+  ///   - clock: The `Clock` to use for timing.
+  ///   - interval: The interval between pings.
   public init<C: Clock>(
     session: URLSession = .operationConnectivity,
     url: URL = .operationURLConnectionObserverDefault,
@@ -128,9 +135,9 @@ extension URLConnectionObserver {
   /// Creates an observer and starts pinging the URL.
   ///
   /// - Parameters:
-  ///   - session: The URL session to use for pinging.
+  ///   - session: The `URLSession` to use for pinging.
   ///   - url: The URL to ping.
-  ///   - clock: The clock to use for timing.
+  ///   - clock: The `Clock` to use for timing.
   ///   - interval: The interval between pings.
   /// - Returns: A running `URLConnectionObserver`.
   public static func starting<C: Clock>(

--- a/Sources/OperationCore/NetworkObserving/URLConnectionObserver.swift
+++ b/Sources/OperationCore/NetworkObserving/URLConnectionObserver.swift
@@ -100,7 +100,23 @@ public final class URLConnectionObserver: NetworkObserver, Sendable {
       _ = try await session.data(for: request)
       return .connected
     } catch {
-      return .disconnected
+      return self.isProblematicConnectionError(error) ? .disconnected : .connected
+    }
+  }
+
+  private func isProblematicConnectionError(_ error: any Error) -> Bool {
+    guard let error = error as? URLError else { return false }
+
+    return switch error.code {
+    case .notConnectedToInternet,
+      .networkConnectionLost,
+      .timedOut,
+      .internationalRoamingOff,
+      .callIsActive,
+      .dataNotAllowed:
+      true
+    default:
+      false
     }
   }
 }

--- a/Sources/OperationCore/NetworkObserving/URLConnectionObserver.swift
+++ b/Sources/OperationCore/NetworkObserving/URLConnectionObserver.swift
@@ -17,9 +17,9 @@ public final class URLConnectionObserver: NetworkObserver, Sendable {
     var task: Task<Void, Never>?
   }
 
-  private let observe: @Sendable (URLConnectionObserver) async -> Void
+  private let observe: @Sendable (WeakBox<URLConnectionObserver>) async -> Void
 
-  private let state = Lock(State())
+  private let state = RecursiveLock(State())
   private let subscriptions = OperationSubscriptions<@Sendable (NetworkConnectionStatus) -> Void>()
 
   /// True if the observer is actively pinging the URL.
@@ -34,8 +34,9 @@ public final class URLConnectionObserver: NetworkObserver, Sendable {
     pingingEvery interval: Duration = .seconds(120)
   ) where C.Duration == Duration {
     self.observe = { observer in
-      await observer.ping(to: url, using: session)
+      await observer.value?.ping(to: url, using: session)
       for await _ in _AsyncTimerSequence(interval: interval, clock: clock) {
+        guard let observer = observer.value else { return }
         await observer.ping(to: url, using: session)
       }
     }
@@ -46,8 +47,7 @@ public final class URLConnectionObserver: NetworkObserver, Sendable {
     self.state.withLock {
       $0.task?.cancel()
       $0.task = Task { [weak self] in
-        guard let self else { return }
-        await self.observe(self)
+        await self?.observe(WeakBox(value: self))
       }
     }
   }

--- a/Tests/OperationTests/NetworkObservingTests/URLConnectionObserverTests.swift
+++ b/Tests/OperationTests/NetworkObservingTests/URLConnectionObserverTests.swift
@@ -1,0 +1,301 @@
+import Clocks
+import CustomDump
+import Foundation
+import Operation
+import Testing
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+@Suite("URLConnectionObserver tests", .serialized)
+struct URLConnectionObserverTests {
+  @Test("Is Running Returns True After Init")
+  @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
+  func isRunningReturnsTrueAfterInit() async throws {
+    MockURLProtocol.setHandler { _ in throw SomeError() }
+    let observer = URLConnectionObserver(session: Self.makeSession(), clock: TestClock())
+
+    expectNoDifference(observer.isRunning, false)
+  }
+
+  @Test("Is Running Returns False After Stop")
+  @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
+  func isRunningReturnsFalseAfterStop() async throws {
+    MockURLProtocol.setHandler { _ in throw SomeError() }
+    let observer = URLConnectionObserver.starting(session: Self.makeSession(), clock: TestClock())
+
+    observer.stop()
+
+    expectNoDifference(observer.isRunning, false)
+  }
+
+  @Test("Starting Factory Creates Running Observer")
+  @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
+  func startingFactoryCreatesRunningObserver() async throws {
+    MockURLProtocol.setHandler { _ in throw SomeError() }
+    let observer = URLConnectionObserver.starting(
+      session: Self.makeSession(),
+      clock: TestClock(),
+      pingingEvery: .seconds(1)
+    )
+
+    expectNoDifference(observer.isRunning, true)
+    observer.stop()
+  }
+
+  @Test("Starting Shared Works Correctly")
+  @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
+  func startingSharedWorksCorrectly() async throws {
+    MockURLProtocol.setHandler { _ in throw SomeError() }
+
+    let observer = URLConnectionObserver.startingShared()
+
+    expectNoDifference(observer.isRunning, true)
+  }
+
+  @Test("Initial Failed Ping Becomes Disconnected")
+  @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
+  func initialFailedPingBecomesDisconnected() async throws {
+    MockURLProtocol.setHandler { _ in throw SomeError() }
+    let observer = URLConnectionObserver(session: Self.makeSession(), clock: TestClock())
+
+    let status = try await self.nextStatus(from: observer, where: { $0 == .disconnected })
+
+    expectNoDifference(status, .disconnected)
+    expectNoDifference(observer.currentStatus, .disconnected)
+  }
+
+  @Test("Later Successful Ping Becomes Connected")
+  @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
+  func laterSuccessfulPingBecomesConnected() async throws {
+    let attempts = Counter()
+    let clock = TestClock()
+    MockURLProtocol.setHandler { request in
+      if attempts.increment() < 2 {
+        throw SomeError()
+      }
+      return (Self.makeResponse(for: request.url!), Data())
+    }
+
+    let observer = URLConnectionObserver(
+      session: Self.makeSession(),
+      clock: clock,
+      pingingEvery: .seconds(1)
+    )
+
+    let disconnected = try await self.nextStatus(from: observer, where: { $0 == .disconnected })
+    expectNoDifference(disconnected, .disconnected)
+
+    await clock.advance(by: .zero)
+    await clock.advance(by: .seconds(1))
+
+    let connected = try await self.nextStatus(from: observer, where: { $0 == .connected })
+    expectNoDifference(connected, .connected)
+    expectNoDifference(observer.currentStatus, .connected)
+  }
+
+  @Test("Connected -> Disconnected -> Connected")
+  @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
+  func connectedToDisconnectedToConnected() async throws {
+    let attempts = Counter()
+    let clock = TestClock()
+    MockURLProtocol.setHandler { request in
+      let attempt = attempts.increment()
+      if attempt % 2 == 1 {
+        return (Self.makeResponse(for: request.url!), Data())
+      }
+      throw SomeError()
+    }
+
+    let observer = URLConnectionObserver(
+      session: Self.makeSession(),
+      clock: clock,
+      pingingEvery: .seconds(1)
+    )
+
+    let connected = try await self.nextStatus(from: observer, where: { $0 == .connected })
+    expectNoDifference(connected, .connected)
+
+    await clock.advance(by: .seconds(1))
+
+    let disconnected = try await self.nextStatus(from: observer, where: { $0 == .disconnected })
+    expectNoDifference(disconnected, .disconnected)
+
+    await clock.advance(by: .seconds(1))
+
+    let connectedAgain = try await self.nextStatus(from: observer, where: { $0 == .connected })
+    expectNoDifference(connectedAgain, .connected)
+    expectNoDifference(observer.currentStatus, .connected)
+  }
+
+  @Test("Disconnected -> Connected -> Disconnected")
+  @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
+  func disconnectedToConnectedToDisconnected() async throws {
+    let attempts = Counter()
+    let clock = TestClock()
+    MockURLProtocol.setHandler { request in
+      let attempt = attempts.increment()
+      if attempt % 2 == 0 {
+        return (Self.makeResponse(for: request.url!), Data())
+      }
+      throw SomeError()
+    }
+
+    let observer = URLConnectionObserver(
+      session: Self.makeSession(),
+      clock: clock,
+      pingingEvery: .seconds(1)
+    )
+
+    let disconnected = try await self.nextStatus(from: observer, where: { $0 == .disconnected })
+    expectNoDifference(disconnected, .disconnected)
+
+    await clock.advance(by: .seconds(1))
+
+    let connected = try await self.nextStatus(from: observer, where: { $0 == .connected })
+    expectNoDifference(connected, .connected)
+
+    await clock.advance(by: .seconds(1))
+
+    let disconnectedAgain = try await self.nextStatus(
+      from: observer,
+      where: { $0 == .disconnected }
+    )
+    expectNoDifference(disconnectedAgain, .disconnected)
+    expectNoDifference(observer.currentStatus, .disconnected)
+  }
+
+  @Test("Duplicate Statuses Do Not Notify Subscribers")
+  @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
+  func duplicateStatusesDoNotNotifySubscribers() async throws {
+    let clock = TestClock()
+    MockURLProtocol.setHandler { request in
+      (Self.makeResponse(for: request.url!), Data())
+    }
+
+    let observer = URLConnectionObserver(
+      session: Self.makeSession(),
+      clock: clock,
+      pingingEvery: .seconds(1)
+    )
+    let statuses = StatusBox()
+    let subscription = observer.subscribe { status in
+      statuses.append(status)
+    }
+    defer { subscription.cancel() }
+
+    await clock.advance(by: .zero)
+    await clock.advance(by: .seconds(1))
+
+    expectNoDifference(statuses.values, [.connected])
+    expectNoDifference(observer.currentStatus, .connected)
+  }
+
+  private struct SomeError: Error {}
+
+  private func nextStatus(
+    from observer: URLConnectionObserver,
+    where predicate: @escaping @Sendable (NetworkConnectionStatus) -> Bool
+  ) async throws -> NetworkConnectionStatus {
+    try await withThrowingTaskGroup(of: NetworkConnectionStatus.self) { group in
+      group.addTask {
+        let stream = AsyncThrowingStream<NetworkConnectionStatus, any Error> { continuation in
+          let subscription = observer.subscribe { status in
+            continuation.yield(status)
+          }
+          continuation.onTermination = { _ in
+            subscription.cancel()
+          }
+        }
+
+        for try await status in stream {
+          if predicate(status) {
+            return status
+          }
+        }
+
+        throw SomeError()
+      }
+
+      group.addTask {
+        try await Task.sleep(for: .seconds(1))
+        throw SomeError()
+      }
+
+      let status = try await group.next()!
+      group.cancelAll()
+      return status
+    }
+  }
+
+  private static func makeSession() -> URLSession {
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [MockURLProtocol.self]
+    return URLSession(configuration: configuration)
+  }
+
+  private static func makeResponse(for url: URL) -> HTTPURLResponse {
+    HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
+  }
+}
+
+private final class Counter: Sendable {
+  private let lock = Lock(0)
+
+  func increment() -> Int {
+    self.lock.withLock {
+      $0 += 1
+      return $0
+    }
+  }
+}
+
+private final class StatusBox: Sendable {
+  private let statuses = Lock([NetworkConnectionStatus]())
+
+  var values: [NetworkConnectionStatus] {
+    self.statuses.withLock { $0 }
+  }
+
+  func append(_ status: NetworkConnectionStatus) {
+    self.statuses.withLock { $0.append(status) }
+  }
+}
+
+private final class MockURLProtocol: URLProtocol, @unchecked Sendable {
+  nonisolated(unsafe) private static var handler:
+    @Sendable (URLRequest) throws -> (
+      HTTPURLResponse,
+      Data
+    ) = { _ in
+      fatalError("Unhandled request.")
+    }
+
+  static func setHandler(
+    _ handler: @escaping @Sendable (URLRequest) throws -> (HTTPURLResponse, Data)
+  ) {
+    Self.handler = handler
+  }
+
+  override class func canInit(with request: URLRequest) -> Bool {
+    true
+  }
+
+  override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    request
+  }
+
+  override func startLoading() {
+    do {
+      let (response, data) = try Self.handler(self.request)
+      self.client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+      self.client?.urlProtocol(self, didLoad: data)
+      self.client?.urlProtocolDidFinishLoading(self)
+    } catch {
+      self.client?.urlProtocol(self, didFailWithError: error)
+    }
+  }
+
+  override func stopLoading() {}
+}

--- a/Tests/OperationTests/NetworkObservingTests/URLConnectionObserverTests.swift
+++ b/Tests/OperationTests/NetworkObservingTests/URLConnectionObserverTests.swift
@@ -8,7 +8,7 @@ import Testing
   import FoundationNetworking
 #endif
 
-@Suite("URLConnectionObserver tests", .serialized)
+@Suite("URLConnectionObserver tests", .serialized, .timeLimit(.minutes(1)))
 struct URLConnectionObserverTests {
   @Test("Is Running Returns True After Init")
   @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
@@ -60,7 +60,7 @@ struct URLConnectionObserverTests {
     MockURLProtocol.setHandler { _ in throw SomeError() }
     let observer = URLConnectionObserver(session: Self.makeSession(), clock: TestClock())
 
-    let status = try await self.nextStatus(from: observer, where: { $0 == .disconnected })
+    let status = await self.nextStatus(from: observer, where: { $0 == .disconnected })
 
     expectNoDifference(status, .disconnected)
     expectNoDifference(observer.currentStatus, .disconnected)
@@ -84,13 +84,13 @@ struct URLConnectionObserverTests {
       pingingEvery: .seconds(1)
     )
 
-    let disconnected = try await self.nextStatus(from: observer, where: { $0 == .disconnected })
+    let disconnected = await self.nextStatus(from: observer, where: { $0 == .disconnected })
     expectNoDifference(disconnected, .disconnected)
 
     await clock.advance(by: .zero)
     await clock.advance(by: .seconds(1))
 
-    let connected = try await self.nextStatus(from: observer, where: { $0 == .connected })
+    let connected = await self.nextStatus(from: observer, where: { $0 == .connected })
     expectNoDifference(connected, .connected)
     expectNoDifference(observer.currentStatus, .connected)
   }
@@ -114,17 +114,17 @@ struct URLConnectionObserverTests {
       pingingEvery: .seconds(1)
     )
 
-    let connected = try await self.nextStatus(from: observer, where: { $0 == .connected })
+    let connected = await self.nextStatus(from: observer, where: { $0 == .connected })
     expectNoDifference(connected, .connected)
 
     await clock.advance(by: .seconds(1))
 
-    let disconnected = try await self.nextStatus(from: observer, where: { $0 == .disconnected })
+    let disconnected = await self.nextStatus(from: observer, where: { $0 == .disconnected })
     expectNoDifference(disconnected, .disconnected)
 
     await clock.advance(by: .seconds(1))
 
-    let connectedAgain = try await self.nextStatus(from: observer, where: { $0 == .connected })
+    let connectedAgain = await self.nextStatus(from: observer, where: { $0 == .connected })
     expectNoDifference(connectedAgain, .connected)
     expectNoDifference(observer.currentStatus, .connected)
   }
@@ -148,17 +148,17 @@ struct URLConnectionObserverTests {
       pingingEvery: .seconds(1)
     )
 
-    let disconnected = try await self.nextStatus(from: observer, where: { $0 == .disconnected })
+    let disconnected = await self.nextStatus(from: observer, where: { $0 == .disconnected })
     expectNoDifference(disconnected, .disconnected)
 
     await clock.advance(by: .seconds(1))
 
-    let connected = try await self.nextStatus(from: observer, where: { $0 == .connected })
+    let connected = await self.nextStatus(from: observer, where: { $0 == .connected })
     expectNoDifference(connected, .connected)
 
     await clock.advance(by: .seconds(1))
 
-    let disconnectedAgain = try await self.nextStatus(
+    let disconnectedAgain = await self.nextStatus(
       from: observer,
       where: { $0 == .disconnected }
     )
@@ -197,36 +197,24 @@ struct URLConnectionObserverTests {
   private func nextStatus(
     from observer: URLConnectionObserver,
     where predicate: @escaping @Sendable (NetworkConnectionStatus) -> Bool
-  ) async throws -> NetworkConnectionStatus {
-    try await withThrowingTaskGroup(of: NetworkConnectionStatus.self) { group in
-      group.addTask {
-        let stream = AsyncThrowingStream<NetworkConnectionStatus, any Error> { continuation in
-          let subscription = observer.subscribe { status in
-            continuation.yield(status)
-          }
-          continuation.onTermination = { _ in
-            subscription.cancel()
-          }
-        }
-
-        for try await status in stream {
-          if predicate(status) {
-            return status
-          }
-        }
-
-        throw SomeError()
+  ) async -> NetworkConnectionStatus {
+    let stream = AsyncStream<NetworkConnectionStatus> { continuation in
+      let subscription = observer.subscribe { status in
+        continuation.yield(status)
       }
-
-      group.addTask {
-        try await Task.sleep(for: .seconds(1))
-        throw SomeError()
+      continuation.onTermination = { _ in
+        subscription.cancel()
       }
-
-      let status = try await group.next()!
-      group.cancelAll()
-      return status
     }
+
+    for await status in stream {
+      if predicate(status) {
+        return status
+      }
+    }
+
+    Issue.record("Expected connection status stream to produce a matching value.")
+    fatalError("Unreachable")
   }
 
   private static func makeSession() -> URLSession {

--- a/Tests/OperationTests/NetworkObservingTests/URLConnectionObserverTests.swift
+++ b/Tests/OperationTests/NetworkObservingTests/URLConnectionObserverTests.swift
@@ -57,7 +57,7 @@ struct URLConnectionObserverTests {
   @Test("Initial Failed Ping Becomes Disconnected")
   @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
   func initialFailedPingBecomesDisconnected() async throws {
-    MockURLProtocol.setHandler { _ in throw SomeError() }
+    MockURLProtocol.setHandler { _ in throw URLError(.notConnectedToInternet) }
     let observer = URLConnectionObserver(session: Self.makeSession(), clock: TestClock())
 
     let status = await self.nextStatus(from: observer, where: { $0 == .disconnected })
@@ -73,7 +73,7 @@ struct URLConnectionObserverTests {
     let clock = TestClock()
     MockURLProtocol.setHandler { request in
       if attempts.increment() < 2 {
-        throw SomeError()
+        throw URLError(.networkConnectionLost)
       }
       return (Self.makeResponse(for: request.url!), Data())
     }
@@ -105,7 +105,7 @@ struct URLConnectionObserverTests {
       if attempt % 2 == 1 {
         return (Self.makeResponse(for: request.url!), Data())
       }
-      throw SomeError()
+      throw URLError(.timedOut)
     }
 
     let observer = URLConnectionObserver(
@@ -139,7 +139,7 @@ struct URLConnectionObserverTests {
       if attempt % 2 == 0 {
         return (Self.makeResponse(for: request.url!), Data())
       }
-      throw SomeError()
+      throw URLError(.dataNotAllowed)
     }
 
     let observer = URLConnectionObserver(
@@ -173,6 +173,30 @@ struct URLConnectionObserverTests {
     MockURLProtocol.setHandler { request in
       (Self.makeResponse(for: request.url!), Data())
     }
+
+    let observer = URLConnectionObserver(
+      session: Self.makeSession(),
+      clock: clock,
+      pingingEvery: .seconds(1)
+    )
+    let statuses = StatusBox()
+    let subscription = observer.subscribe { status in
+      statuses.append(status)
+    }
+    defer { subscription.cancel() }
+
+    await clock.advance(by: .zero)
+    await clock.advance(by: .seconds(1))
+
+    expectNoDifference(statuses.values, [.connected])
+    expectNoDifference(observer.currentStatus, .connected)
+  }
+
+  @Test("Non Connection Errors Stay Connected")
+  @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
+  func nonConnectionErrorsStayConnected() async throws {
+    let clock = TestClock()
+    MockURLProtocol.setHandler { _ in throw SomeError() }
 
     let observer = URLConnectionObserver(
       session: Self.makeSession(),


### PR DESCRIPTION
Adds a new `NetworkObserver` that checks the connection status by periodically pinging a URL. This is useful for detecting actual internet connection over just connection to wifi.

Additionally, we can make this the default `NetworkObserver` for Linux, Windows, and Android.