### PR TITLE
OperationClient Subscriptions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
   macos:
     name: macOS (Swift 6.2)
     runs-on: macos-26
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       matrix:
         xcode: ["26.0"]

--- a/Sources/OperationCore/Client/OperationClient.swift
+++ b/Sources/OperationCore/Client/OperationClient.swift
@@ -432,8 +432,12 @@ extension OperationClient {
 // MARK: - Subscribe
 
 extension OperationClient {
+  /// A description of stores added to and removed from an ``OperationClient`` subscription.
   public struct OpaqueSubscriptionChange: Sendable {
+    /// Stores added to the client during this change.
     public fileprivate(set) var storesAdded = OperationPathableCollection<OpaqueOperationStore>()
+
+    /// Stores removed from the client during this change.
     public fileprivate(set) var storesRemoved = OperationPathableCollection<OpaqueOperationStore>()
 
     fileprivate var isEmpty: Bool {
@@ -441,6 +445,25 @@ extension OperationClient {
     }
   }
 
+  /// Subscribes to stores being added to and removed from this client.
+  ///
+  /// The subscription is scoped to stores whose paths match the specified path prefix.
+  ///
+  /// ```swift
+  /// let subscription = client.subscribe(matching: ["users"]) { change in
+  ///   for store in change.storesAdded {
+  ///     print("Added store at path: \(store.path)")
+  ///   }
+  ///   for store in change.storesRemoved {
+  ///     print("Removed store at path: \(store.path)")
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// - Parameters:
+  ///   - path: A path prefix used to filter which store changes are observed.
+  ///   - onChange: A closure invoked whenever matching stores are added or removed.
+  /// - Returns: An ``OperationSubscription``.
   public func subscribe(
     matching path: OperationPath = OperationPath(),
     onChange: @Sendable @escaping (OpaqueSubscriptionChange) -> Void
@@ -451,8 +474,12 @@ extension OperationClient {
     }
   }
 
+  /// A description of typed stores added to and removed from an ``OperationClient`` subscription.
   public struct SubscriptionChange<State: OperationState & Sendable>: Sendable {
+    /// Stores of the subscribed state type added to the client during this change.
     public let storesAdded: OperationPathableCollection<OperationStore<State>>
+
+    /// Stores of the subscribed state type removed from the client during this change.
     public let storesRemoved: OperationPathableCollection<OperationStore<State>>
 
     fileprivate var isEmpty: Bool {
@@ -460,6 +487,31 @@ extension OperationClient {
     }
   }
 
+  /// Subscribes to stores of a specific state type being added to and removed from this client.
+  ///
+  /// The subscription is scoped to stores whose paths match the specified path prefix, and only
+  /// stores of the requested state type are included in the emitted change.
+  ///
+  /// ```swift
+  /// let subscription = client.subscribe(
+  ///   matching: ["users"],
+  ///   state: QueryState<User, any Error>.self
+  /// ) { change in
+  ///   for store in change.storesAdded {
+  ///     print("Added user store at path: \(store.path)")
+  ///   }
+  ///   for store in change.storesRemoved {
+  ///     print("Removed user store at path: \(store.path)")
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// - Parameters:
+  ///   - path: A path prefix used to filter which store changes are observed.
+  ///   - state: The state type of stores to observe.
+  ///   - onChange: A closure invoked whenever matching stores of the specified state type are added
+  ///     or removed.
+  /// - Returns: An ``OperationSubscription``.
   public func subscribe<State: OperationState>(
     matching path: OperationPath = OperationPath(),
     state: State.Type,

--- a/Sources/OperationCore/Client/OperationClient.swift
+++ b/Sources/OperationCore/Client/OperationClient.swift
@@ -63,8 +63,25 @@ import IssueReporting
 /// <doc:OperationDefaults>.
 public final class OperationClient: Sendable {
   private struct State {
+    struct Subscription {
+      let handler: @Sendable (OpaqueSubscriptionChange) -> Void
+      let matchablePath: OperationPath
+    }
+
     var initialContext: OperationContext
     var operationTypes = [OperationPath: Any.Type]()
+    var subscriptions = OperationSubscriptions<Subscription>()
+
+    func sendSubscriptionChange(change: OpaqueSubscriptionChange) {
+      self.subscriptions.forEach { subscription in
+        let change = OpaqueSubscriptionChange(
+          storesAdded: change.storesAdded.collection(matching: subscription.matchablePath),
+          storesRemoved: change.storesRemoved.collection(matching: subscription.matchablePath)
+        )
+        guard !change.isEmpty else { return }
+        subscription.handler(change)
+      }
+    }
   }
 
   private let storeCreator: any StoreCreator & Sendable
@@ -224,7 +241,11 @@ extension OperationClient {
           return opaqueStore.base as! OperationStore<Operation.State>
         }
         let store = create(createStore, transfer)
-        stores.update(OpaqueOperationStore(erasing: store))
+        let opaqueStore = OpaqueOperationStore(erasing: store)
+        state.sendSubscriptionChange(
+          change: OpaqueSubscriptionChange(storesAdded: [opaqueStore])
+        )
+        stores.update(opaqueStore)
         return store
       }
     }
@@ -285,7 +306,14 @@ extension OperationClient {
   ///
   /// - Parameter path: The path of the stores.
   public func clearStores(matching path: OperationPath = OperationPath()) {
-    self.storeCache.withStores { $0.removeAll(matching: path) }
+    self.state.withLock { state in
+      let stores = self.storeCache.withStores {
+        let stores = $0.collection(matching: path)
+        $0.removeAll(matching: path)
+        return stores
+      }
+      state.sendSubscriptionChange(change: OpaqueSubscriptionChange(storesRemoved: stores))
+    }
   }
 
   /// Removes the store with the specified ``OperationPath``.
@@ -296,7 +324,15 @@ extension OperationClient {
   /// - Returns: The removed store as an ``OpaqueOperationStore``.
   @discardableResult
   public func clearStore(with path: OperationPath) -> OpaqueOperationStore? {
-    self.storeCache.withStores { $0.removeValue(forPath: path) }
+    self.state.withLock { state in
+      let store = self.storeCache.withStores { $0.removeValue(forPath: path) }
+      state.sendSubscriptionChange(
+        change: OpaqueSubscriptionChange(
+          storesRemoved: store.map { [$0] } ?? OperationPathableCollection()
+        )
+      )
+      return store
+    }
   }
 }
 
@@ -326,16 +362,20 @@ extension OperationClient {
         let beforeEntries = stores.collection(matching: path)
         var afterEntries = beforeEntries
         let value = try fn(&afterEntries, createStore)
+        var change = OpaqueSubscriptionChange()
         for store in afterEntries {
           if beforeEntries[store.path] == nil {
+            change.storesAdded.update(store)
             stores.update(store)
           }
         }
         for store in beforeEntries {
           if afterEntries[store.path] == nil {
+            change.storesRemoved.update(store)
             stores.removeValue(forPath: store.path)
           }
         }
+        state.sendSubscriptionChange(change: change)
         return value
       }
     }
@@ -368,18 +408,74 @@ extension OperationClient {
         )
         var afterEntries = beforeEntries
         let value = try fn(&afterEntries, createStore)
+        var change = OpaqueSubscriptionChange()
         for store in afterEntries {
           if beforeEntries[store.path] == nil {
-            stores.update(OpaqueOperationStore(erasing: store))
+            let store = OpaqueOperationStore(erasing: store)
+            change.storesAdded.update(store)
+            stores.update(store)
           }
         }
         for store in beforeEntries {
           if afterEntries[store.path] == nil {
+            change.storesRemoved.update(OpaqueOperationStore(erasing: store))
             stores.removeValue(forPath: store.path)
           }
         }
+        state.sendSubscriptionChange(change: change)
         return value
       }
+    }
+  }
+}
+
+// MARK: - Subscribe
+
+extension OperationClient {
+  public struct OpaqueSubscriptionChange: Sendable {
+    public fileprivate(set) var storesAdded = OperationPathableCollection<OpaqueOperationStore>()
+    public fileprivate(set) var storesRemoved = OperationPathableCollection<OpaqueOperationStore>()
+
+    fileprivate var isEmpty: Bool {
+      self.storesAdded.isEmpty && self.storesRemoved.isEmpty
+    }
+  }
+
+  public func subscribe(
+    matching path: OperationPath = OperationPath(),
+    onChange: @Sendable @escaping (OpaqueSubscriptionChange) -> Void
+  ) -> OperationSubscription {
+    self.state.withLock { state in
+      let subscription = State.Subscription(handler: onChange, matchablePath: path)
+      return state.subscriptions.add(handler: subscription).subscription
+    }
+  }
+
+  public struct SubscriptionChange<State: OperationState & Sendable>: Sendable {
+    public let storesAdded: OperationPathableCollection<OperationStore<State>>
+    public let storesRemoved: OperationPathableCollection<OperationStore<State>>
+
+    fileprivate var isEmpty: Bool {
+      self.storesAdded.isEmpty && self.storesRemoved.isEmpty
+    }
+  }
+
+  public func subscribe<State: OperationState>(
+    matching path: OperationPath = OperationPath(),
+    state: State.Type,
+    onChange: @Sendable @escaping (SubscriptionChange<State>) -> Void
+  ) -> OperationSubscription {
+    self.subscribe(matching: path) { change in
+      let change = SubscriptionChange(
+        storesAdded: OperationPathableCollection(
+          change.storesAdded.compactMap { $0.base as? OperationStore<State> }
+        ),
+        storesRemoved: OperationPathableCollection(
+          change.storesRemoved.compactMap { $0.base as? OperationStore<State> }
+        )
+      )
+      guard !change.isEmpty else { return }
+      onChange(change)
     }
   }
 }

--- a/Tests/OperationTests/ClientTests/OperationClientTests.swift
+++ b/Tests/OperationTests/ClientTests/OperationClientTests.swift
@@ -308,6 +308,417 @@ struct OperationClientTests {
     }
     expectNoDifference(isEmpty, true)
   }
+
+  @Test("Subscribe On Added Fires When Store Is Created After Subscription")
+  func subscribeOnAddedFiresWhenStoreIsCreatedAfterSubscription() async throws {
+    let client = OperationClient()
+    let addedStores = RecursiveLock(OperationPathableCollection<OperationStore<TestQuery.State>>())
+    let subscription = client.subscribe(
+      state: TestQuery.State.self,
+      onChange: { change in
+        addedStores.withLock { stores in
+          for store in change.storesAdded {
+            stores.update(store)
+          }
+        }
+      }
+    )
+
+    let store = client.store(for: TestQuery())
+    let stores = addedStores.withLock { $0 }
+    expectNoDifference(stores.count, 1)
+    expectNoDifference(stores.first === store, true)
+    _ = subscription
+  }
+
+  @Test("Subscribe On Added Does Not Fire For Stores Created Before Subscription")
+  func subscribeOnAddedDoesNotFireForStoresCreatedBeforeSubscription() async throws {
+    let client = OperationClient()
+    _ = client.store(for: TestQuery())
+
+    let addedStores = RecursiveLock(OperationPathableCollection<OperationStore<TestQuery.State>>())
+    let subscription = client.subscribe(
+      state: TestQuery.State.self,
+      onChange: { change in
+        addedStores.withLock { stores in
+          for store in change.storesAdded {
+            stores.update(store)
+          }
+        }
+      }
+    )
+
+    let stores = addedStores.withLock { $0 }
+    expectNoDifference(stores.count, 0)
+    _ = subscription
+  }
+
+  @Test("Subscribe On Removed Fires When Store Is Cleared")
+  func subscribeOnRemovedFiresWhenStoreIsCleared() async throws {
+    let client = OperationClient()
+    let q1 = TaggedPathableQuery(value: 1, path: [1, 2])
+    let store = client.store(for: q1)
+
+    let removedStores = RecursiveLock(
+      OperationPathableCollection<OperationStore<TaggedPathableQuery<Int>.State>>()
+    )
+    let subscription = client.subscribe(
+      state: TaggedPathableQuery<Int>.State.self,
+      onChange: { change in
+        removedStores.withLock { stores in
+          for store in change.storesRemoved {
+            stores.update(store)
+          }
+        }
+      }
+    )
+
+    client.clearStore(with: q1.path)
+    let stores = removedStores.withLock { $0 }
+    expectNoDifference(stores.count, 1)
+    expectNoDifference(stores.first === store, true)
+    _ = subscription
+  }
+
+  @Test("Subscribe On Removed Fires When Stores Are Cleared Via Matching Path")
+  func subscribeOnRemovedFiresWhenStoresAreClearedViaMatchingPath() async throws {
+    let client = OperationClient()
+    let q1 = TaggedPathableQuery(value: 1, path: [1, 2])
+    let q2 = TaggedPathableQuery(value: 2, path: [1, 3])
+    let q3 = TaggedPathableQuery(value: 3, path: [2, 4])
+    _ = client.store(for: q1)
+    let store2 = client.store(for: q2)
+    _ = client.store(for: q3)
+
+    let removedStores = RecursiveLock(
+      OperationPathableCollection<OperationStore<TaggedPathableQuery<Int>.State>>()
+    )
+    let subscription = client.subscribe(
+      state: TaggedPathableQuery<Int>.State.self,
+      onChange: { change in
+        removedStores.withLock { stores in
+          for store in change.storesRemoved {
+            stores.update(store)
+          }
+        }
+      }
+    )
+
+    client.clearStores(matching: [1])
+    let stores = removedStores.withLock { $0 }
+    expectNoDifference(stores.count, 2)
+    expectNoDifference(stores.contains(where: { $0 === store2 }), true)
+    _ = subscription
+  }
+
+  @Test("Subscribe Matching Filters Added And Removed Stores By Path Prefix")
+  func subscribeMatchingFiltersAddedAndRemovedStoresByPathPrefix() async throws {
+    let client = OperationClient()
+    let matchingQuery = TaggedPathableQuery(value: 1, path: [1, 2])
+    let nonMatchingQuery = TaggedPathableQuery(value: 2, path: [2, 3])
+
+    let addedStores = RecursiveLock(
+      OperationPathableCollection<OperationStore<TaggedPathableQuery<Int>.State>>()
+    )
+    let removedStores = RecursiveLock(
+      OperationPathableCollection<OperationStore<TaggedPathableQuery<Int>.State>>()
+    )
+    let subscription = client.subscribe(
+      matching: [1],
+      state: TaggedPathableQuery<Int>.State.self,
+      onChange: { change in
+        addedStores.withLock { stores in
+          for store in change.storesAdded {
+            stores.update(store)
+          }
+        }
+        removedStores.withLock { stores in
+          for store in change.storesRemoved {
+            stores.update(store)
+          }
+        }
+      }
+    )
+
+    let matchingStore = client.store(for: matchingQuery)
+    let nonMatchingStore = client.store(for: nonMatchingQuery)
+    client.clearStore(with: matchingQuery.path)
+    client.clearStore(with: nonMatchingQuery.path)
+
+    let storesAdded = addedStores.withLock { $0 }
+    let storesRemoved = removedStores.withLock { $0 }
+    expectNoDifference(storesAdded.count, 1)
+    expectNoDifference(storesAdded.first === matchingStore, true)
+    expectNoDifference(storesAdded.contains(where: { $0 === nonMatchingStore }), false)
+    expectNoDifference(storesRemoved.count, 1)
+    expectNoDifference(storesRemoved.first === matchingStore, true)
+    expectNoDifference(storesRemoved.contains(where: { $0 === nonMatchingStore }), false)
+    _ = subscription
+  }
+
+  @Test("Subscribe Only Receives Stores Of Specified State Type")
+  func subscribeOnlyReceivesStoresOfSpecifiedStateType() async throws {
+    let client = OperationClient()
+    _ = client.store(for: TaggedPathableQuery(value: 1, path: [1, 2]))
+    _ = client.store(for: TaggedPathableQuery(value: 2, path: [2, 3]))
+
+    let intAdded = RecursiveLock(
+      OperationPathableCollection<OperationStore<TaggedPathableQuery<Int>.State>>()
+    )
+    let stringAdded = RecursiveLock(
+      OperationPathableCollection<OperationStore<TaggedPathableQuery<String>.State>>()
+    )
+    let intSubscription = client.subscribe(
+      state: TaggedPathableQuery<Int>.State.self,
+      onChange: { change in
+        intAdded.withLock { stores in
+          for store in change.storesAdded {
+            stores.update(store)
+          }
+        }
+      }
+    )
+    let stringSubscription = client.subscribe(
+      state: TaggedPathableQuery<String>.State.self,
+      onChange: { change in
+        stringAdded.withLock { stores in
+          for store in change.storesAdded {
+            stores.update(store)
+          }
+        }
+      }
+    )
+
+    expectNoDifference(intAdded.withLock { $0.count }, 0)
+    expectNoDifference(stringAdded.withLock { $0.count }, 0)
+
+    _ = client.store(for: TaggedPathableQuery(value: 3, path: [3, 4]))
+    expectNoDifference(intAdded.withLock { $0.count }, 1)
+    expectNoDifference(stringAdded.withLock { $0.count }, 0)
+
+    _ = client.store(for: TaggedPathableQuery(value: "foo", path: [3, 5]))
+    expectNoDifference(intAdded.withLock { $0.count }, 1)
+    expectNoDifference(stringAdded.withLock { $0.count }, 1)
+    _ = intSubscription
+    _ = stringSubscription
+  }
+
+  @Test("Typed Subscribe Wraps Opaque Subscribe Correctly")
+  func typedSubscribeWrapsOpaqueSubscribeCorrectly() async throws {
+    let client = OperationClient()
+    let q1 = PathableQuery(value: 1, path: [1, 2])
+
+    let opaqueAdded = RecursiveLock(OperationPathableCollection<OpaqueOperationStore>())
+    let typedAdded = RecursiveLock(OperationPathableCollection<OperationStore<QueryState<Int, any Error>>>())
+    let opaqueSubscription = client.subscribe { change in
+      opaqueAdded.withLock { stores in
+        for store in change.storesAdded {
+          stores.update(store)
+        }
+      }
+    }
+    let typedSubscription = client.subscribe(
+      state: QueryState<Int, any Error>.self,
+      onChange: { change in
+        typedAdded.withLock { stores in
+          for store in change.storesAdded {
+            stores.update(store)
+          }
+        }
+      }
+    )
+
+    let store = client.store(for: q1)
+
+    expectNoDifference(opaqueAdded.withLock { $0.count }, 1)
+    expectNoDifference(typedAdded.withLock { $0.count }, 1)
+    expectNoDifference(
+      opaqueAdded.withLock { $0.first?.base as? OperationStore<QueryState<Int, any Error>> } === store,
+      true
+    )
+    expectNoDifference(typedAdded.withLock { $0.first } === store, true)
+    _ = opaqueSubscription
+    _ = typedSubscription
+  }
+
+  @Test("Subscribe On Removed Fires When All Stores Are Cleared")
+  func subscribeOnRemovedFiresWhenAllStoresAreCleared() async throws {
+    let client = OperationClient()
+    let q1 = PathableQuery(value: 1, path: [1, 2])
+    let q2 = PathableQuery(value: 2, path: [2, 3])
+    _ = client.store(for: q1)
+    let store2 = client.store(for: q2)
+
+    let removedStores = RecursiveLock(OperationPathableCollection<OperationStore<QueryState<Int, any Error>>>())
+    let subscription = client.subscribe(
+      state: QueryState<Int, any Error>.self,
+      onChange: { change in
+        removedStores.withLock { stores in
+          for store in change.storesRemoved {
+            stores.update(store)
+          }
+        }
+      }
+    )
+
+    client.clearStores()
+    let stores = removedStores.withLock { $0 }
+    expectNoDifference(stores.count, 2)
+    expectNoDifference(stores.contains(where: { $0 === store2 }), true)
+    _ = subscription
+  }
+
+  @Test("Subscribe On Added Fires When Multiple Stores Created Via WithStores")
+  func subscribeOnAddedFiresWhenMultipleStoresCreatedViaWithStores() async throws {
+    let client = OperationClient()
+    let q1 = TaggedPathableQuery(value: 1, path: [1, 2])
+    let q2 = TaggedPathableQuery(value: 2, path: [1, 3])
+    let q3 = TaggedPathableQuery(value: 3, path: [2, 4])
+
+    let addedStores = RecursiveLock(
+      OperationPathableCollection<OperationStore<TaggedPathableQuery<Int>.State>>()
+    )
+    let subscription = client.subscribe(
+      state: TaggedPathableQuery<Int>.State.self,
+      onChange: { change in
+        addedStores.withLock { stores in
+          for store in change.storesAdded {
+            stores.update(store)
+          }
+        }
+      }
+    )
+
+    client.withStores(matching: []) { entries, createStore in
+      entries.update(OpaqueOperationStore(erasing: createStore(for: q1)))
+      entries.update(OpaqueOperationStore(erasing: createStore(for: q2)))
+      entries.update(OpaqueOperationStore(erasing: createStore(for: q3)))
+    }
+
+    let stores = addedStores.withLock { $0 }
+    expectNoDifference(stores.count, 3)
+    _ = subscription
+  }
+
+  @Test("Subscribe On Removed Fires When Multiple Stores Removed Via WithStores")
+  func subscribeOnRemovedFiresWhenMultipleStoresRemovedViaWithStores() async throws {
+    let client = OperationClient()
+    let q1 = TaggedPathableQuery(value: 1, path: [1, 2])
+    let q2 = TaggedPathableQuery(value: 2, path: [1, 3])
+    let q3 = TaggedPathableQuery(value: 3, path: [2, 4])
+    let q4 = TaggedPathableQuery(value: 4, path: [2, 5])
+    _ = client.store(for: q1)
+    _ = client.store(for: q2)
+    _ = client.store(for: q3)
+    let store4 = client.store(for: q4)
+
+    let removedStores = RecursiveLock(
+      OperationPathableCollection<OperationStore<TaggedPathableQuery<Int>.State>>()
+    )
+    let subscription = client.subscribe(
+      state: TaggedPathableQuery<Int>.State.self,
+      onChange: { change in
+        removedStores.withLock { stores in
+          for store in change.storesRemoved {
+            stores.update(store)
+          }
+        }
+      }
+    )
+
+    client.withStores(matching: [1]) { entries, _ in
+      entries.removeValue(forPath: q1.path)
+      entries.removeValue(forPath: q2.path)
+    }
+
+    let stores = removedStores.withLock { $0 }
+    expectNoDifference(stores.count, 2)
+    expectNoDifference(stores.contains(where: { $0 === store4 }), false)
+    _ = subscription
+  }
+
+  @Test("Subscribe On Added Fires Through Typed WithStores")
+  func subscribeOnAddedFiresThroughTypedWithStores() async throws {
+    let client = OperationClient()
+    let q1 = TaggedPathableQuery(value: 1, path: [1, 2])
+    let q2 = TaggedPathableQuery(value: 2, path: [1, 3])
+
+    let addedStores = RecursiveLock(
+      OperationPathableCollection<OperationStore<TaggedPathableQuery<Int>.State>>()
+    )
+    let subscription = client.subscribe(
+      state: TaggedPathableQuery<Int>.State.self,
+      onChange: { change in
+        addedStores.withLock { stores in
+          for store in change.storesAdded {
+            stores.update(store)
+          }
+        }
+      }
+    )
+
+    client.withStores(matching: [], of: TaggedPathableQuery<Int>.State.self) { entries, createStore in
+      entries.update(createStore(for: q1))
+      entries.update(createStore(for: q2))
+    }
+
+    let stores = addedStores.withLock { $0 }
+    expectNoDifference(stores.count, 2)
+    _ = subscription
+  }
+
+  @Test("Subscribe On Change Does Not Fire When WithStores Makes No Changes")
+  func subscribeOnChangeDoesNotFireWhenWithStoresMakesNoChanges() async throws {
+    let client = OperationClient()
+    _ = client.store(for: TaggedPathableQuery(value: 1, path: [1, 2]))
+
+    let changeCount = RecursiveLock(0)
+    let subscription = client.subscribe(
+      state: TaggedPathableQuery<Int>.State.self,
+      onChange: { _ in
+        changeCount.withLock { $0 += 1 }
+      }
+    )
+
+    client.withStores(matching: [1], of: TaggedPathableQuery<Int>.State.self) { stores, _ in
+      expectNoDifference(stores.count, 1)
+    }
+
+    changeCount.withLock { expectNoDifference($0, 0) }
+    _ = subscription
+  }
+
+  @Test("Subscribe On Removed Fires Through Typed WithStores")
+  func subscribeOnRemovedFiresThroughTypedWithStores() async throws {
+    let client = OperationClient()
+    let q1 = TaggedPathableQuery(value: 1, path: [1, 2])
+    let q2 = TaggedPathableQuery(value: 2, path: [1, 3])
+    _ = client.store(for: q1)
+    let store2 = client.store(for: q2)
+
+    let removedStores = RecursiveLock(
+      OperationPathableCollection<OperationStore<TaggedPathableQuery<Int>.State>>()
+    )
+    let subscription = client.subscribe(
+      state: TaggedPathableQuery<Int>.State.self,
+      onChange: { change in
+        removedStores.withLock { stores in
+          for store in change.storesRemoved {
+            stores.update(store)
+          }
+        }
+      }
+    )
+
+    _ = client.withStores(matching: [], of: TaggedPathableQuery<Int>.State.self) { entries, _ in
+      entries.removeValue(forPath: q2.path)
+    }
+
+    let stores = removedStores.withLock { $0 }
+    expectNoDifference(stores.count, 1)
+    expectNoDifference(stores.first === store2, true)
+    _ = subscription
+  }
 }
 
 private final class CountingController<State: OperationState>: OperationController, Sendable


### PR DESCRIPTION
Adds an `OperationClient.subscribe` method to allow observing when new stores are added and removed from the client. This is particularly useful for scenarios such as implementing global loading indicators and the like.

You can also pass a prefix path to match with to ensure updates only for a select amount of stores. There's also typed and opaque versions of the subscription.